### PR TITLE
USB4000 now supported

### DIFF
--- a/hardwarelibrary/spectrometers/oceaninsight.py
+++ b/hardwarelibrary/spectrometers/oceaninsight.py
@@ -815,10 +815,10 @@ class USB4000(OISpectrometer):
 
         """
         self.epCommandOut.write(b'\xfe')
-        parameters = array.array('B',[0]*self.inputEndpoints[2].wMaxPacketSize)
-        nReadBytes = self.inputEndpoints[2].read(size_or_buffer=parameters, timeout=1000)
+        buffer = array.array('B',[0]*self.inputEndpoints[2].wMaxPacketSize)
+        nReadBytes = self.inputEndpoints[2].read(size_or_buffer=buffer, timeout=1000)
 
-        statusList = unpack('<hL?BBB?Bxx?x',parameters[:16])
+        statusList = unpack('<hL?BBB?Bxx?x',buffer[:16])
         status = StatusUSB4000(*statusList)
         self.lastStatus = status
         return status
@@ -897,6 +897,10 @@ class USB4000(OISpectrometer):
         complete and will raise the ready flag when the spectrum is ready
         to be retrieved.
 
+        The documentation for the USB4000 is not clear: the acquisition status
+        is either 0,2,3,4 and it appears that 2 is when data is requested, but
+        this is empirically determined.
+
         Returns
         -------
         isSpectrumRequested : bool
@@ -911,6 +915,10 @@ class USB4000(OISpectrometer):
 
     def isSpectrumReady(self):
         """ The requested spectrum is ready to be retrieved with getSpectrumData.
+        
+        The documentation for the USB4000 is not clear: the acquisition status
+        is either 0,2,3,4 and it appears that 4 is when data is ready, but
+        this is empirically determined.
 
         Returns
         -------

--- a/hardwarelibrary/spectrometers/oceaninsight.py
+++ b/hardwarelibrary/spectrometers/oceaninsight.py
@@ -758,9 +758,8 @@ class USB2000(OISpectrometer):
         """ Set the integration time in an integer value of milliseconds 
         for a spectrum. If the value is smaller than 3 ms, it will be unchanged.
         """
-        hi = timeInMs // 256
-        lo = timeInMs % 256        
-        self.epCommandOut.write([0x02, lo, hi])
+        self.sendCommand(cmdBytes = b'\x02',
+                         payloadBytes = pack('<H',int(timeInMs)))
 
 
 class USB4000(OISpectrometer):
@@ -868,7 +867,7 @@ class USB4000(OISpectrometer):
         for a spectrum. If the value is smaller than 3 ms, it will be unchanged.
         """
         self.sendCommand(cmdBytes = b'\x02',
-                         payloadBytes = pack('<L',int(timeInMs*1000)))
+                         payloadBytes = pack('<L',int(timeInMs*self.timeScale)))
 
     def isSpectrumRequested(self) -> bool:
         """ The spectrometer is currently waiting for an acquisition to
@@ -1050,7 +1049,7 @@ class SpectraViewer:
             time = float(self.integrationTimeBox.text)
             if time == 0:
                 raise ValueError('Requested integration time is invalid: \
-the text "{0}" converts to 0.  Use a valid value (≥3).')
+the text "{0}" converts to 0.')
             self.spectrometer.setIntegrationTime(time)
             plt.pause(0.3)
             self.axes.autoscale_view()


### PR DESCRIPTION
Reworked the classes to support USB2000 and USB4000 Spectrometers from Ocean Insight.
There are several differences between the two.  When needed, the subclass must override the default implementeation.
`getSpectrum` must always be implemented ecause there is no default implementation.