### PR TITLE
SutterDevice as LinearMotionDevice

### DIFF
--- a/hardwarelibrary/motion/sutterdevice.py
+++ b/hardwarelibrary/motion/sutterdevice.py
@@ -16,13 +16,15 @@ class SutterDevice(LinearMotionDevice):
     def __init__(self, serialNumber: str = None):
         super().__init__(serialNumber=serialNumber, vendorId=4930, productId=1)
         self.port = None
+        self.nativeStepsPerMicrons = 16
+
+        # All values are in native units (i.e. microsteps)
         self.xMinLimit = 0
         self.yMinLimit = 0
         self.zMinLimit = 0
-        self.xMaxLimit = 25000
-        self.yMaxLimit = 25000
-        self.zMaxLimit = 25000
-        self.microstepsPerMicrons = 16
+        self.xMaxLimit = 25000*16
+        self.yMaxLimit = 25000*16
+        self.zMaxLimit = 25000*16
 
     def __del__(self):
         try:

--- a/hardwarelibrary/motion/sutterdevice.py
+++ b/hardwarelibrary/motion/sutterdevice.py
@@ -120,8 +120,7 @@ class SutterDevice(LinearMotionDevice):
         if replyBytes is None:
             raise Exception(f"Nothing received in respnse to {commandBytes}")
         if replyBytes != (b'\r',):
-            raise Exception(f"Expected carriage return, but got {replyBytes} instead.")
-        
+            raise Exception(f"Expected carriage return, but got {replyBytes} instead.")     
         
     def work(self):
         self.home()

--- a/hardwarelibrary/tests/testLinearMotionDevice.py
+++ b/hardwarelibrary/tests/testLinearMotionDevice.py
@@ -157,10 +157,10 @@ class TestDebugLinearMotionDeviceBase(BaseTestCases.TestLinearMotionDevice):
         super().setUp()
         self.device = DebugLinearMotionDevice()
 
-# class TestDebugSutterDeviceBase(BaseTestCases.TestLinearMotionDevice):
-#     def setUp(self):
-#         super().setUp()
-#         self.device = SutterDevice("debug")
+class TestDebugSutterDeviceBase(BaseTestCases.TestLinearMotionDevice):
+    def setUp(self):
+        super().setUp()
+        self.device = SutterDevice("debug")
 
 
 if __name__ == '__main__':

--- a/hardwarelibrary/tests/testSutterDevice.py
+++ b/hardwarelibrary/tests/testSutterDevice.py
@@ -12,13 +12,31 @@ import serial
 class TestSutterDevice(unittest.TestCase):
     def setUp(self):
             # pyftdi.ftdi.Ftdi.add_custom_product(vid=4930, pid=1, pidname='Sutter')
-        self.device = SutterDevice("debug")
+        try: 
+            self.device = SutterDevice()
+            self.device.initializeDevice()
+        except:
+            self.device = SutterDevice("debug")
+            self.device.initializeDevice()
+            #print("Using Debug Sutter device for tests")
+        
         self.assertIsNotNone(self.device)
-        self.device.doInitializeDevice()
+        # raise(unittest.SkipTest("No FTDI connected. Skipping."))
 
     def tearDown(self):
-        self.device.doShutdownDevice()
+        self.device.shutdownDevice()
         self.device = None
+
+    def testNativeUnits(self):
+        self.assertEqual(self.device.nativeStepsPerMicrons, 16)
+
+    def testLimits(self):
+        self.assertEqual(self.device.xMinLimit, 0)
+        self.assertEqual(self.device.yMinLimit, 0)
+        self.assertEqual(self.device.zMinLimit, 0)
+        self.assertEqual(self.device.xMaxLimit, 25000*16)
+        self.assertEqual(self.device.yMaxLimit, 25000*16)
+        self.assertEqual(self.device.zMaxLimit, 25000*16)
 
     def testDeviceHome(self):
         self.device.home()


### PR DESCRIPTION
The parent class `LinearMotionDevice` manages notifications, conversions from native to micron units, etc...
`SutterDevice` was developed independently originally, but has been switched to use the `PhysicalDevice->LinearMotionDevice` hierarchy.

The general design of `LinearMotionDevice` is that user functions (move, position etc...) have a simple name and take care of notifying others, managing the state of the device etc... It does not "perform" the action by itself.  It calls another function the the children must implement: `doMoveTo`, `doGetPosition`, `doHome` etc.... So when creating a new device, one only needs to implement a few functions...!

So, please take a look at all functions that `LinearMotionDevice` [provides](https://github.com/DCC-Lab/PyHardwareLibrary/blob/76fcc52aa76ac9f05fdbd0016f1ac51456c220a2/hardwarelibrary/motion/linearmotiondevice.py). Notice the conversion is performed in the base class and the subclass gets it for free.

All tests work fine.