### PR TITLE
Notification name as enums

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,16 +2,21 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="e1a2b906-4e8f-4edb-8efe-d2e272bf62ab" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/PyHardwareLibrary.iml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/PyHardwareLibrary.iml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/hardwarelibrary/tests/testMapPositionsFunction.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/hardwarelibrary/motion/sutterdevice.py" beforeDir="false" afterPath="$PROJECT_DIR$/hardwarelibrary/motion/sutterdevice.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/hardwarelibrary/tests/testSutter.py" beforeDir="false" afterPath="$PROJECT_DIR$/hardwarelibrary/tests/testSutter.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/hardwarelibrary/motion/linearmotiondevice.py" beforeDir="false" afterPath="$PROJECT_DIR$/hardwarelibrary/motion/linearmotiondevice.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
     <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="Python Script" />
+      </list>
+    </option>
   </component>
   <component name="FlaskConsoleOptions" custom-start-script="import sys&#10;sys.path.extend([WORKING_DIR_AND_PYTHON_PATHS])&#10;from flask.cli import ScriptInfo&#10;locals().update(ScriptInfo(create_app=None).load_app().make_shell_context())&#10;print(&quot;Python %s on %s\nApp: %s [%s]\nInstance: %s&quot; % (sys.version, sys.platform, app.import_name, app.env, app.instance_path))">
     <envs>
@@ -31,8 +36,6 @@
     <setting file="file://$PROJECT_DIR$/hardwarelibrary/communication/serialport.py" root0="FORCE_HIGHLIGHTING" />
     <setting file="file:///Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pyftdi/ftdi.py" root0="SKIP_INSPECTION" />
     <setting file="file:///Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pyftdi/usbtools.py" root0="SKIP_INSPECTION" />
-    <setting file="file://$PROJECT_DIR$/hardwarelibrary/communication/sutter.py" root0="FORCE_HIGHLIGHTING" />
-    <setting file="file://$PROJECT_DIR$/hardwarelibrary/tests/testSutter.py" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/hardwarelibrary/motion/sutterdevice.py" root0="FORCE_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/hardwarelibrary/physicaldevice.py" root0="FORCE_HIGHLIGHTING" />
   </component>
@@ -57,21 +60,18 @@
     <property name="restartRequiresConfirmation" value="false" />
     <property name="settings.editor.selected.configurable" value="com.jetbrains.python.configuration.PyActiveSdkModuleConfigurable" />
   </component>
-  <component name="RunManager" selected="Python tests.Unittests for testSutter.TestSutterDevice.testPosition">
-    <configuration name="Unittests for testSutter.TestSutterDevice.testDeviceHome" type="tests" factoryName="Unittests" temporary="true" nameIsGenerated="true">
+  <component name="RunManager" selected="Python tests.Unittests for testMapPositionsFunction.TestMapPositionsFunction">
+    <configuration name="Unittests for testMapPositionsFunction.TestMapPositionsFunction" type="tests" factoryName="Unittests" temporary="true" nameIsGenerated="true">
       <module name="PyHardwareLibrary" />
       <option name="INTERPRETER_OPTIONS" value="" />
       <option name="PARENT_ENVS" value="true" />
-      <envs>
-        <env name="PYTHONUNBUFFERED" value="1" />
-      </envs>
       <option name="SDK_HOME" value="" />
       <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/hardwarelibrary/tests" />
       <option name="IS_MODULE_SDK" value="true" />
       <option name="ADD_CONTENT_ROOTS" value="true" />
       <option name="ADD_SOURCE_ROOTS" value="true" />
       <option name="_new_additionalArguments" value="&quot;&quot;" />
-      <option name="_new_target" value="&quot;testSutter.TestSutterDevice.testDeviceHome&quot;" />
+      <option name="_new_target" value="&quot;testMapPositionsFunction.TestMapPositionsFunction&quot;" />
       <option name="_new_targetType" value="&quot;PYTHON&quot;" />
       <method v="2" />
     </configuration>
@@ -135,19 +135,19 @@
       <method v="2" />
     </configuration>
     <list>
+      <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testDeviceMoveBy" />
       <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testDeviceMove" />
       <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testDevicePosition" />
-      <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testDeviceMoveBy" />
-      <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testDeviceHome" />
       <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testPosition" />
+      <item itemvalue="Python tests.Unittests for testMapPositionsFunction.TestMapPositionsFunction" />
     </list>
     <recent_temporary>
       <list>
+        <item itemvalue="Python tests.Unittests for testMapPositionsFunction.TestMapPositionsFunction" />
         <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testPosition" />
         <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testDeviceMoveBy" />
         <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testDeviceMove" />
         <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testDevicePosition" />
-        <item itemvalue="Python tests.Unittests for testSutter.TestSutterDevice.testDeviceHome" />
       </list>
     </recent_temporary>
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,6 +2,9 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="e1a2b906-4e8f-4edb-8efe-d2e272bf62ab" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/hardwarelibrary/motion/linearmotiondevice.py" beforeDir="false" afterPath="$PROJECT_DIR$/hardwarelibrary/motion/linearmotiondevice.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/hardwarelibrary/motion/sutterdevice.py" beforeDir="false" afterPath="$PROJECT_DIR$/hardwarelibrary/motion/sutterdevice.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/hardwarelibrary/tests/testMapPositionsFunction.py" beforeDir="false" afterPath="$PROJECT_DIR$/hardwarelibrary/tests/testMapPositionsFunction.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,8 +2,7 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="e1a2b906-4e8f-4edb-8efe-d2e272bf62ab" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/hardwarelibrary/motion/linearmotiondevice.py" beforeDir="false" afterPath="$PROJECT_DIR$/hardwarelibrary/motion/linearmotiondevice.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/hardwarelibrary/tests/testMapPositionsFunction.py" beforeDir="false" afterPath="$PROJECT_DIR$/hardwarelibrary/tests/testMapPositionsFunction.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="e1a2b906-4e8f-4edb-8efe-d2e272bf62ab" name="Default Changelist" comment="">
-      <change afterPath="$PROJECT_DIR$/hardwarelibrary/tests/testMapPositionsFunction.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/hardwarelibrary/motion/linearmotiondevice.py" beforeDir="false" afterPath="$PROJECT_DIR$/hardwarelibrary/motion/linearmotiondevice.py" afterDir="false" />
     </list>

--- a/hardwarelibrary/motion/linearmotiondevice.py
+++ b/hardwarelibrary/motion/linearmotiondevice.py
@@ -56,7 +56,7 @@ class LinearMotionDevice(PhysicalDevice):
         positionInMicrons = [x / self.nativeStepsPerMicrons for x in position]
         return positionInMicrons
 
-    def mapPositions(self, width: int, height: int, stepInMicrons: int, direction="leftRight"):
+    def mapPositions(self, width: int, height: int, stepInMicrons: int, direction: str = "leftRight"):
         """mapPositions(width, height, stepInMicrons[, direction == "leftRight" or "zigzag"])
 
         Returns a list of position tuples, which can be used directly in moveTo functions, to map a sample."""

--- a/hardwarelibrary/motion/linearmotiondevice.py
+++ b/hardwarelibrary/motion/linearmotiondevice.py
@@ -9,8 +9,8 @@ class NotificationName(Enum):
     didGetPosition = "didGetPosition"
 
 class Direction(Enum):
-    unidirectional = "leftRight"
-    bidirectional  = "zigzag"
+    unidirectional = "unidirectional"
+    bidirectional  = "bidirectional"
 
 class LinearMotionDevice(PhysicalDevice):
 

--- a/hardwarelibrary/motion/linearmotiondevice.py
+++ b/hardwarelibrary/motion/linearmotiondevice.py
@@ -38,20 +38,47 @@ class LinearMotionDevice(PhysicalDevice):
         NotificationCenter().postNotification("didMove", notifyingObject=self)
 
     def moveInMicronsTo(self, position):
-        nativePosition = [ x * self.nativeStepsPerMicrons for x in position]
+        nativePosition = [x * self.nativeStepsPerMicrons for x in position]
         self.moveTo(nativePosition)
 
     def moveInMicronsBy(self, displacement):
-        nativeDisplacement = [ dx * self.nativeStepsPerMicrons for dx in displacement]
+        nativeDisplacement = [dx * self.nativeStepsPerMicrons for dx in displacement]
         self.moveTo(nativeDisplacement)
 
     def positionInMicrons(self):
         position = self.position()
-        positionInMicrons = [ x / self.nativeStepsPerMicrons for x in position]
+        positionInMicrons = [x / self.nativeStepsPerMicrons for x in position]
         return positionInMicrons
 
-class DebugLinearMotionDevice(LinearMotionDevice):
+    def mapPositions(self, width: int, height: int, stepInMicrons: int, direction="leftRight"):
+        """mapPositions(width, height, stepInMicrons[, direction == "leftRight" or "zigzag"])
 
+        Returns a list of position tuples, which can be used directly in moveTo functions, to map a sample."""
+
+        initWidth, initHeight, depth = self.positionInMicrons()
+        mapPositions = []
+        for countHeight in range(height):
+            y = initHeight + countHeight * stepInMicrons
+            if direction == "leftRight":
+                for countWidth in range(width):
+                    x = initWidth + countWidth*stepInMicrons
+                    position = (x, y, depth)
+                    mapPositions.append(position)
+            if direction == "zigzag":
+                if countHeight % 2 == 0:
+                    for countWidth in range(width):
+                        x = initWidth + countWidth * stepInMicrons
+                        position = (x, y, depth)
+                        mapPositions.append(position)
+                elif countHeight % 2 == 1:
+                    for countWidth in range(width-1, -1, -1):
+                        x = initWidth + countWidth * stepInMicrons
+                        position = (x, y, depth)
+                        mapPositions.append(position)
+        return mapPositions
+
+
+class DebugLinearMotionDevice(LinearMotionDevice):
     def __init__(self):
         super().__init__("debug", 0xffff, 0xfffd)
         (self.x, self.y, self.z) = (0,0,0)

--- a/hardwarelibrary/motion/linearmotiondevice.py
+++ b/hardwarelibrary/motion/linearmotiondevice.py
@@ -3,7 +3,7 @@ from hardwarelibrary.physicaldevice import *
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification
 import numpy as np
 
-class LinearMotionNotification(Notification.Name):
+class LinearMotionNotification(Enum):
     willMove       = "willMove"
     didMove        = "didMove"
     didGetPosition = "didGetPosition"

--- a/hardwarelibrary/motion/linearmotiondevice.py
+++ b/hardwarelibrary/motion/linearmotiondevice.py
@@ -8,6 +8,10 @@ class NotificationName(Enum):
     didMove        = "didMove"
     didGetPosition = "didGetPosition"
 
+class Direction(Enum):
+    unidirectional = "leftRight"
+    bidirectional  = "zigzag"
+
 class LinearMotionDevice(PhysicalDevice):
 
     def __init__(self, serialNumber:str, productId:np.uint32, vendorId:np.uint32):
@@ -56,7 +60,7 @@ class LinearMotionDevice(PhysicalDevice):
         positionInMicrons = [x / self.nativeStepsPerMicrons for x in position]
         return tuple(positionInMicrons)
 
-    def mapPositions(self, width: int, height: int, stepInMicrons: int, direction: str = "leftRight"):
+    def mapPositions(self, width: int, height: int, stepInMicrons: float, direction: Direction = Direction.unidirectional):
         """mapPositions(width, height, stepInMicrons[, direction == "leftRight" or "zigzag"])
 
         Returns a list of position tuples, which can be used directly in moveTo functions, to map a sample."""
@@ -65,12 +69,12 @@ class LinearMotionDevice(PhysicalDevice):
         mapPositions = []
         for countHeight in range(height):
             y = initHeight + countHeight * stepInMicrons
-            if direction == "leftRight":
+            if Direction(direction) == Direction.unidirectional:
                 for countWidth in range(width):
                     x = initWidth + countWidth*stepInMicrons
                     position = (x, y, depth)
                     mapPositions.append(position)
-            if direction == "zigzag":
+            elif Direction(direction) == Direction.bidirectional:
                 if countHeight % 2 == 0:
                     for countWidth in range(width):
                         x = initWidth + countWidth * stepInMicrons
@@ -81,6 +85,8 @@ class LinearMotionDevice(PhysicalDevice):
                         x = initWidth + countWidth * stepInMicrons
                         position = (x, y, depth)
                         mapPositions.append(position)
+            else:
+                raise ValueError("Invalid direction: {0}".format(direction))
         return mapPositions
 
 

--- a/hardwarelibrary/motion/linearmotiondevice.py
+++ b/hardwarelibrary/motion/linearmotiondevice.py
@@ -54,14 +54,14 @@ class LinearMotionDevice(PhysicalDevice):
     def positionInMicrons(self):
         position = self.position()
         positionInMicrons = [x / self.nativeStepsPerMicrons for x in position]
-        return positionInMicrons
+        return tuple(positionInMicrons)
 
     def mapPositions(self, width: int, height: int, stepInMicrons: int, direction: str = "leftRight"):
         """mapPositions(width, height, stepInMicrons[, direction == "leftRight" or "zigzag"])
 
         Returns a list of position tuples, which can be used directly in moveTo functions, to map a sample."""
 
-        initWidth, initHeight, depth = self.positionInMicrons()
+        (initWidth, initHeight, depth) = self.positionInMicrons()
         mapPositions = []
         for countHeight in range(height):
             y = initHeight + countHeight * stepInMicrons
@@ -87,7 +87,7 @@ class LinearMotionDevice(PhysicalDevice):
 class DebugLinearMotionDevice(LinearMotionDevice):
     def __init__(self):
         super().__init__("debug", 0xffff, 0xfffd)
-        (self.x, self.y, self.z) = (0,0,0)
+        (self.x, self.y, self.z) = (0, 0, 0)
         self.nativeStepsPerMicrons = 16
 
     def doGetPosition(self) -> (float, float, float):
@@ -95,7 +95,7 @@ class DebugLinearMotionDevice(LinearMotionDevice):
 
     def doMoveTo(self, position):
         x, y, z = position
-        (self.x, self.y, self.z) = (x,y,z)
+        (self.x, self.y, self.z) = (x, y, z)
 
     def doMoveBy(self, displacement):
         dx, dy, dz = displacement
@@ -104,7 +104,7 @@ class DebugLinearMotionDevice(LinearMotionDevice):
         self.z += dz
 
     def doHome(self):
-        (self.x, self.y, self.z) = (0,0,0)
+        (self.x, self.y, self.z) = (0, 0, 0)
 
     def doInitializeDevice(self):
         pass

--- a/hardwarelibrary/motion/linearmotiondevice.py
+++ b/hardwarelibrary/motion/linearmotiondevice.py
@@ -1,9 +1,9 @@
-from hardwarelibrary.physicaldevice import *
-from hardwarelibrary.notificationcenter import NotificationCenter
-import numpy as np
 from enum import Enum
+from hardwarelibrary.physicaldevice import *
+from hardwarelibrary.notificationcenter import NotificationCenter, Notification
+import numpy as np
 
-class NotificationName(Enum):
+class LinearMotionNotification(Notification.Name):
     willMove       = "willMove"
     didMove        = "didMove"
     didGetPosition = "didGetPosition"
@@ -28,24 +28,24 @@ class LinearMotionDevice(PhysicalDevice):
         self.zMaxLimit = None
 
     def moveTo(self, position):
-        NotificationCenter().postNotification(NotificationName.willMove.value, notifyingObject=self, userInfo=position)
+        NotificationCenter().postNotification(LinearMotionNotification.willMove, notifyingObject=self, userInfo=position)
         self.doMoveTo(position)
-        NotificationCenter().postNotification(NotificationName.didMove.value, notifyingObject=self, userInfo=position)
+        NotificationCenter().postNotification(LinearMotionNotification.didMove, notifyingObject=self, userInfo=position)
 
     def moveBy(self, displacement):
-        NotificationCenter().postNotification(NotificationName.willMove.value, notifyingObject=self, userInfo=displacement)
+        NotificationCenter().postNotification(LinearMotionNotification.willMove, notifyingObject=self, userInfo=displacement)
         self.doMoveBy(displacement)
-        NotificationCenter().postNotification(NotificationName.didMove.value, notifyingObject=self, userInfo=displacement)
+        NotificationCenter().postNotification(LinearMotionNotification.didMove, notifyingObject=self, userInfo=displacement)
 
     def position(self) -> ():
         position = self.doGetPosition()
-        NotificationCenter().postNotification(NotificationName.didGetPosition.value, notifyingObject=self, userInfo=position)
+        NotificationCenter().postNotification(LinearMotionNotification.didGetPosition, notifyingObject=self, userInfo=position)
         return position
 
     def home(self) -> ():
-        NotificationCenter().postNotification(NotificationName.willMove.value, notifyingObject=self)
+        NotificationCenter().postNotification(LinearMotionNotification.willMove, notifyingObject=self)
         self.doHome()
-        NotificationCenter().postNotification(NotificationName.didMove.value, notifyingObject=self)
+        NotificationCenter().postNotification(LinearMotionNotification.didMove, notifyingObject=self)
 
     def moveInMicronsTo(self, position):
         nativePosition = [x * self.nativeStepsPerMicrons for x in position]

--- a/hardwarelibrary/motion/sutterdevice.py
+++ b/hardwarelibrary/motion/sutterdevice.py
@@ -51,7 +51,6 @@ class SutterDevice(LinearMotionDevice):
                 if self.port.isOpen:
                     self.port.close()
             raise PhysicalDevice.UnableToInitialize(error)
-        
 
     def doShutdownDevice(self):
         self.port.close()
@@ -86,10 +85,10 @@ class SutterDevice(LinearMotionDevice):
         # print(unpack(format, replyBytes))
         return unpack(format, replyBytes)
 
-    def positionInMicrosteps(self) -> (int,int,int): # for compatibility
+    def positionInMicrosteps(self) -> (int, int, int):  # for compatibility
         return self.doGetPosition()
 
-    def doGetPosition(self) -> (int,int,int):
+    def doGetPosition(self) -> (int, int, int):
         """ Returns the position in microsteps """
         commandBytes = pack('<cc', b'C', b'\r')
         self.sendCommand(commandBytes)
@@ -108,8 +107,8 @@ class SutterDevice(LinearMotionDevice):
             raise Exception(f"Expected carriage return, but got '{reply}' instead.")
 
     def doMoveBy(self, displacement):
-        dx,dy,dz  = displacement
-        x,y,z = self.doGetPosition()
+        dx, dy, dz = displacement
+        x, y, z = self.doGetPosition()
         if x is not None:
             self.doMoveTo((x+dx, y+dy, z+dz))
         else:

--- a/hardwarelibrary/notificationcenter.py
+++ b/hardwarelibrary/notificationcenter.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
-# You must define notification names like this for simplicity:
-# class DeviceNotification(NotificationName):
+# You must define notification names like this:
+# class DeviceNotification(Notification.Name):
 #    willMove       = "willMove"
 #    didMove        = "didMove"
 #    didGetPosition = "didGetPosition"

--- a/hardwarelibrary/notificationcenter.py
+++ b/hardwarelibrary/notificationcenter.py
@@ -1,18 +1,16 @@
 from enum import Enum
 
 # You must define notification names like this:
-# class DeviceNotification(Notification.Name):
+# class DeviceNotification(Enum):
 #    willMove       = "willMove"
 #    didMove        = "didMove"
 #    didGetPosition = "didGetPosition"
 
-class Notification:
-    class Name(Enum):
-        pass
 
+class Notification:
     def __init__(self, name, object=None, userInfo=None):
-        if not isinstance(name, Notification.Name):
-            raise ValueError("You must use an enum-subclass of Notification.Name, not a string for the notification name")
+        if not isinstance(name, Enum):
+            raise ValueError("You must use an enum-subclass of Enum, not a string for the notification name")
 
         self.name = name
         self.object = object
@@ -49,36 +47,36 @@ class NotificationCenter:
         return cls._instance
 
     def addObserver(self, observer, method, notificationName=None, observedObject=None):
-        if notificationName is not None and not isinstance(notificationName, Notification.Name):
-            raise ValueError("You must use an enum-subclass of Notification.Name, not a string for the notificationName")
+        if notificationName is not None and not isinstance(notificationName, Enum):
+            raise ValueError("You must use an enum-subclass of Enum, not a string for the notificationName")
 
         observerInfo = ObserverInfo(observer=observer, method=method, notificationName=notificationName, observedObject=observedObject)
 
         if notificationName not in self.observers.keys():
-            self.observers[notificationName.name] = [observerInfo]
+            self.observers[notificationName] = [observerInfo]
         else:
-            if observerInfo not in self.observers[notificationName.name]:
-                self.observers[notificationName.name].append(observerInfo)
+            if observerInfo not in self.observers[notificationName]:
+                self.observers[notificationName].append(observerInfo)
 
     def removeObserver(self, observer, notificationName=None, observedObject=None):
-        if notificationName is not None and not isinstance(notificationName, Notification.Name):
-            raise ValueError("You must use an enum-subclass of Notification.Name, not a string for the notificationName")
+        if notificationName is not None and not isinstance(notificationName, Enum):
+            raise ValueError("You must use an enum-subclass of Enum, not a string for the notificationName")
 
         observerToRemove = ObserverInfo(observer=observer, notificationName=notificationName, observedObject=observedObject)
 
         if notificationName is not None:
-            self.observers[notificationName.name] = [currentObserver for currentObserver in self.observers[notificationName.name] if not currentObserver.matches(observerToRemove) ]
+            self.observers[notificationName] = [currentObserver for currentObserver in self.observers[notificationName] if not currentObserver.matches(observerToRemove) ]
         else:
             for name in self.observers.keys():
                 self.observers[name] = [observer for observer in self.observers[name] if not observer.matches(observerToRemove) ]        
 
     def postNotification(self, notificationName, notifyingObject, userInfo=None):
-        if not isinstance(notificationName, Notification.Name):
-            raise ValueError("You must use an enum-subclass of Notification.Name, not a string for the notificationName")
+        if not isinstance(notificationName, Enum):
+            raise ValueError("You must use an enum-subclass of Enum, not a string for the notificationName")
 
-        if notificationName.name in self.observers.keys():
+        if notificationName in self.observers.keys():
             notification = Notification(notificationName, notifyingObject, userInfo)
-            for observerInfo in self.observers[notificationName.name]:
+            for observerInfo in self.observers[notificationName]:
                 if observerInfo.observedObject is None or observerInfo.observedObject == notifyingObject:
                     observerInfo.method(notification)
 

--- a/hardwarelibrary/physicaldevice.py
+++ b/hardwarelibrary/physicaldevice.py
@@ -9,7 +9,7 @@ class DeviceState(IntEnum):
     Recognized = 2   # Initialization has succeeded, but currently shutdown
     Unrecognized = 3 # Initialization failed
 
-class PhysicalDeviceNotification(Notification.Name):
+class PhysicalDeviceNotification(Enum):
     willInitializeDevice       = "willInitializeDevice"
     didInitializeDevice        = "didInitializeDevice"
     willShutdownDevice         = "willShutdownDevice"

--- a/hardwarelibrary/physicaldevice.py
+++ b/hardwarelibrary/physicaldevice.py
@@ -1,7 +1,7 @@
 from enum import Enum, IntEnum
 import typing
 import numpy as np
-from hardwarelibrary.notificationcenter import NotificationCenter
+from hardwarelibrary.notificationcenter import NotificationCenter, Notification
 
 class DeviceState(IntEnum):
     Unconfigured = 0 # Dont know anything
@@ -9,6 +9,11 @@ class DeviceState(IntEnum):
     Recognized = 2   # Initialization has succeeded, but currently shutdown
     Unrecognized = 3 # Initialization failed
 
+class PhysicalDeviceNotification(Notification.Name):
+    willInitializeDevice       = "willInitializeDevice"
+    didInitializeDevice        = "didInitializeDevice"
+    willShutdownDevice         = "willShutdownDevice"
+    didShutdownDevice          = "didShutdownDevice"
 
 class PhysicalDevice:
     class UnableToInitialize(Exception):
@@ -25,13 +30,13 @@ class PhysicalDevice:
     def initializeDevice(self):
         if self.state != DeviceState.Ready:
             try:
-                NotificationCenter().postNotification("willInitializeDevice", notifyingObject=self)
+                NotificationCenter().postNotification(PhysicalDeviceNotification.willInitializeDevice, notifyingObject=self)
                 self.doInitializeDevice()
                 self.state = DeviceState.Ready
-                NotificationCenter().postNotification("didInitializeDevice", notifyingObject=self)                
+                NotificationCenter().postNotification(PhysicalDeviceNotification.didInitializeDevice, notifyingObject=self)
             except Exception as error:
                 self.state = DeviceState.Unrecognized
-                NotificationCenter().postNotification("didInitializeDevice", notifyingObject=self, userInfo=error)
+                NotificationCenter().postNotification(PhysicalDeviceNotification.didInitializeDevice, notifyingObject=self, userInfo=error)
                 raise PhysicalDevice.UnableToInitialize(error)
 
     def doInitializeDevice(self):
@@ -40,11 +45,11 @@ class PhysicalDevice:
     def shutdownDevice(self):
         if self.state == DeviceState.Ready:
             try:
-                NotificationCenter().postNotification("willShutdownDevice", notifyingObject=self)
+                NotificationCenter().postNotification(PhysicalDeviceNotification.willShutdownDevice, notifyingObject=self)
                 self.doShutdownDevice()
-                NotificationCenter().postNotification("didShutdownDevice", notifyingObject=self)
+                NotificationCenter().postNotification(PhysicalDeviceNotification.didShutdownDevice, notifyingObject=self)
             except Exception as error:
-                NotificationCenter().postNotification("didShutdownDevice", notifyingObject=self, userInfo=error)
+                NotificationCenter().postNotification(PhysicalDeviceNotification.didShutdownDevice, notifyingObject=self, userInfo=error)
                 raise PhysicalDevice.UnableToShutdown(error)
             finally:
                 self.state = DeviceState.Recognized

--- a/hardwarelibrary/tests/testLinearMotionDevice.py
+++ b/hardwarelibrary/tests/testLinearMotionDevice.py
@@ -2,7 +2,7 @@ import env # modifies path
 import unittest
 
 from hardwarelibrary.communication import *
-from hardwarelibrary.motion.linearmotiondevice import DebugLinearMotionDevice, NotificationName
+from hardwarelibrary.motion.linearmotiondevice import DebugLinearMotionDevice, LinearMotionNotification
 from hardwarelibrary.motion.sutterdevice import SutterDevice
 from hardwarelibrary.notificationcenter import NotificationCenter
 
@@ -103,14 +103,14 @@ class BaseTestCases:
             self.didNotificationReceived = True
 
         def testPositionNotifications(self):
-            NotificationCenter().addObserver(self, method=self.handleDid, notification=NotificationName.didGetPosition)
+            NotificationCenter().addObserver(self, method=self.handleDid, notificationName=LinearMotionNotification.didGetPosition)
             (x, y, z) = self.device.position()
             self.assertTrue(self.didNotificationReceived)        
             NotificationCenter().removeObserver(self)
 
         def testDeviceMoveNotifications(self):
-            NotificationCenter().addObserver(self, method=self.handleWill, notification=NotificationName.willMove)
-            NotificationCenter().addObserver(self, method=self.handleDid, notification=NotificationName.didMove)
+            NotificationCenter().addObserver(self, method=self.handleWill, notificationName=LinearMotionNotification.willMove)
+            NotificationCenter().addObserver(self, method=self.handleDid, notificationName=LinearMotionNotification.didMove)
 
             self.assertFalse(self.willNotificationReceived)
             self.assertFalse(self.didNotificationReceived)
@@ -124,8 +124,8 @@ class BaseTestCases:
             NotificationCenter().removeObserver(self)
 
         def testDeviceMoveByNotifications(self):
-            NotificationCenter().addObserver(self, method=self.handleWill, notification=NotificationName.willMove)
-            NotificationCenter().addObserver(self, method=self.handleDid, notification=NotificationName.didMove)
+            NotificationCenter().addObserver(self, method=self.handleWill, notificationName=LinearMotionNotification.willMove)
+            NotificationCenter().addObserver(self, method=self.handleDid, notificationName=LinearMotionNotification.didMove)
 
             self.assertFalse(self.willNotificationReceived)
             self.assertFalse(self.didNotificationReceived)
@@ -139,8 +139,8 @@ class BaseTestCases:
 
         def testDeviceHomeNotifications(self):
 
-            NotificationCenter().addObserver(self, method=self.handleWill, notification=NotificationName.willMove)
-            NotificationCenter().addObserver(self, method=self.handleDid, notification=NotificationName.didMove)
+            NotificationCenter().addObserver(self, method=self.handleWill, notificationName=LinearMotionNotification.willMove)
+            NotificationCenter().addObserver(self, method=self.handleDid, notificationName=LinearMotionNotification.didMove)
 
             self.assertFalse(self.willNotificationReceived)
             self.assertFalse(self.didNotificationReceived)

--- a/hardwarelibrary/tests/testMapPositionsFunction.py
+++ b/hardwarelibrary/tests/testMapPositionsFunction.py
@@ -1,6 +1,6 @@
 import env # modifies path
 import unittest
-from hardwarelibrary.motion.sutterdevice import SutterDevice
+from hardwarelibrary.motion.sutterdevice import SutterDevice, Direction
 
 
 class TestMapPositionsFunction(unittest.TestCase):
@@ -29,7 +29,7 @@ class TestMapPositionsFunction(unittest.TestCase):
             self.assertEqual(ind, 5-el)
 
     def testListIsCompleteInZigzagMap(self):
-        map = self.device.mapPositions(2, 2, 1, "zigzag")
+        map = self.device.mapPositions(2, 2, 1, Direction.bidirectional)
         self.assertIsInstance(map, list)
         for i in range(4):
             self.assertIsInstance(map[i], tuple)
@@ -37,7 +37,7 @@ class TestMapPositionsFunction(unittest.TestCase):
         self.assertTrue(len(map) == 4)
 
     def testListIsCompleteInLeftRightMap(self):
-        map = self.device.mapPositions(2, 2, 3, "leftRight")
+        map = self.device.mapPositions(2, 2, 3, Direction.unidirectional)
         self.assertIsInstance(map, list)
         for i in range(4):
             self.assertIsInstance(map[i], tuple)
@@ -45,24 +45,24 @@ class TestMapPositionsFunction(unittest.TestCase):
         self.assertTrue(len(map) == 4)
 
     def testmoveInMicronsToFromPositionsGivenWithLeftRight(self):
-        map = self.device.mapPositions(2, 2, 3, "leftRight")
+        map = self.device.mapPositions(2, 2, 3, Direction.unidirectional)
         for pos in map:
             self.device.moveInMicronsTo(pos)
             self.assertEqual(pos, self.device.positionInMicrons())
 
     def testmoveInMicronsToFromPositionsGivenWithZigzag(self):
-        map = self.device.mapPositions(2, 2, 3, "zigzag")
+        map = self.device.mapPositions(2, 2, 3, Direction.bidirectional)
         for pos in map:
             self.device.moveInMicronsTo(pos)
             self.assertEqual(pos, self.device.positionInMicrons())
 
     def testListWithInitialPositionNotNull(self):
         self.device.moveInMicronsTo((5, 5, 5))
-        map = self.device.mapPositions(2, 2, 3, "leftRight")
+        map = self.device.mapPositions(2, 2, 3, Direction.unidirectional)
         for pos in map:
             self.device.moveInMicronsTo(pos)
             self.assertEqual(pos, self.device.positionInMicrons())
-        map = self.device.mapPositions(2, 2, 3, "zigzag")
+        map = self.device.mapPositions(2, 2, 3, Direction.bidirectional)
         for pos in map:
             self.device.moveInMicronsTo(pos)
             self.assertEqual(pos, self.device.positionInMicrons())

--- a/hardwarelibrary/tests/testMapPositionsFunction.py
+++ b/hardwarelibrary/tests/testMapPositionsFunction.py
@@ -67,5 +67,6 @@ class TestMapPositionsFunction(unittest.TestCase):
             self.device.moveInMicronsTo(pos)
             self.assertEqual(pos, self.device.positionInMicrons())
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/hardwarelibrary/tests/testMapPositionsFunction.py
+++ b/hardwarelibrary/tests/testMapPositionsFunction.py
@@ -1,0 +1,57 @@
+import unittest
+import time
+from hardwarelibrary.motion.sutterdevice import SutterDevice
+
+
+class TestMapPositionsFunction(unittest.TestCase):
+    def setUp(self):
+        # pyftdi.ftdi.Ftdi.add_custom_product(vid=4930, pid=1, pidname='Sutter')
+        try:
+            self.device = SutterDevice()
+            self.device.initializeDevice()
+        except:
+            self.device = SutterDevice("debug")
+            self.device.initializeDevice()
+            # print("Using Debug Sutter device for tests")
+
+        self.assertIsNotNone(self.device)
+        # raise(unittest.SkipTest("No FTDI connected. Skipping."))
+
+    def tearDown(self):
+        self.device.shutdownDevice()
+        self.device = None
+
+    def testInverseRangeDoesntSeemToWork(self):
+        testList = []
+        for i in range(5, 0, -1):
+            testList.append(i)
+        for ind, el in enumerate(testList):
+            self.assertEqual(ind, 5-el)
+
+    def testListIsCompleteInZigzagMap(self):
+        map = self.device.mapPositions(2, 2, 1, "zigzag")
+        self.assertIsInstance(map, list)
+        for i in range(4):
+            self.assertIsInstance(map[i], tuple)
+            self.assertTrue(len(map[i]) == 3)
+        self.assertTrue(len(map) == 4)
+
+    def testListIsCompleteInLeftRightMap(self):
+        map = self.device.mapPositions(2, 2, 3, "leftRight")
+        self.assertIsInstance(map, list)
+        for i in range(4):
+            self.assertIsInstance(map[i], tuple)
+            self.assertTrue(len(map[i]) == 3)
+        self.assertTrue(len(map) == 4)
+
+    def testMoveToFromPositionsGivenWithLeftRight(self):
+        map = self.device.mapPositions(2, 2, 3, "leftRight")
+        for pos in map:
+            self.device.moveTo(pos)
+            self.assertEqual(pos, self.device.position())
+
+    def testMoveToFromPositionsGivenWithZigzag(self):
+        map = self.device.mapPositions(2, 2, 3, "zigzag")
+        for pos in map:
+            self.device.moveTo(pos)
+            self.assertEqual(pos, self.device.position())

--- a/hardwarelibrary/tests/testMapPositionsFunction.py
+++ b/hardwarelibrary/tests/testMapPositionsFunction.py
@@ -29,7 +29,6 @@ class TestMapPositionsFunction(unittest.TestCase):
 
     def testListIsCompleteInZigzagMap(self):
         map = self.device.mapPositions(2, 2, 1, "zigzag")
-        print(map)
         self.assertIsInstance(map, list)
         for i in range(4):
             self.assertIsInstance(map[i], tuple)
@@ -44,22 +43,25 @@ class TestMapPositionsFunction(unittest.TestCase):
             self.assertTrue(len(map[i]) == 3)
         self.assertTrue(len(map) == 4)
 
-    def testMoveToFromPositionsGivenWithLeftRight(self):
+    def testmoveInMicronsToFromPositionsGivenWithLeftRight(self):
         map = self.device.mapPositions(2, 2, 3, "leftRight")
         for pos in map:
-            self.device.moveTo(pos)
-            self.assertEqual(pos, self.device.position())
+            self.device.moveInMicronsTo(pos)
+            self.assertEqual(pos, self.device.positionInMicrons())
 
-    def testMoveToFromPositionsGivenWithZigzag(self):
+    def testmoveInMicronsToFromPositionsGivenWithZigzag(self):
         map = self.device.mapPositions(2, 2, 3, "zigzag")
         for pos in map:
-            self.device.moveTo(pos)
-            self.assertEqual(pos, self.device.position())
+            self.device.moveInMicronsTo(pos)
+            self.assertEqual(pos, self.device.positionInMicrons())
 
-    def testListWithInitialPositionNotWorkingForNow(self):
-        self.device.moveTo((5, 5, 5))
+    def testListWithInitialPositionNotNull(self):
+        self.device.moveInMicronsTo((5, 5, 5))
         map = self.device.mapPositions(2, 2, 3, "leftRight")
-        print(map)
         for pos in map:
-            self.device.moveTo(pos)
-            self.assertEqual(pos, self.device.position())
+            self.device.moveInMicronsTo(pos)
+            self.assertEqual(pos, self.device.positionInMicrons())
+        map = self.device.mapPositions(2, 2, 3, "zigzag")
+        for pos in map:
+            self.device.moveInMicronsTo(pos)
+            self.assertEqual(pos, self.device.positionInMicrons())

--- a/hardwarelibrary/tests/testMapPositionsFunction.py
+++ b/hardwarelibrary/tests/testMapPositionsFunction.py
@@ -29,6 +29,7 @@ class TestMapPositionsFunction(unittest.TestCase):
 
     def testListIsCompleteInZigzagMap(self):
         map = self.device.mapPositions(2, 2, 1, "zigzag")
+        print(map)
         self.assertIsInstance(map, list)
         for i in range(4):
             self.assertIsInstance(map[i], tuple)
@@ -51,6 +52,14 @@ class TestMapPositionsFunction(unittest.TestCase):
 
     def testMoveToFromPositionsGivenWithZigzag(self):
         map = self.device.mapPositions(2, 2, 3, "zigzag")
+        for pos in map:
+            self.device.moveTo(pos)
+            self.assertEqual(pos, self.device.position())
+
+    def testListWithInitialPositionNotWorkingForNow(self):
+        self.device.moveTo((5, 5, 5))
+        map = self.device.mapPositions(2, 2, 3, "leftRight")
+        print(map)
         for pos in map:
             self.device.moveTo(pos)
             self.assertEqual(pos, self.device.position())

--- a/hardwarelibrary/tests/testMapPositionsFunction.py
+++ b/hardwarelibrary/tests/testMapPositionsFunction.py
@@ -1,5 +1,4 @@
 import unittest
-import time
 from hardwarelibrary.motion.sutterdevice import SutterDevice
 
 

--- a/hardwarelibrary/tests/testNotificationCenter.py
+++ b/hardwarelibrary/tests/testNotificationCenter.py
@@ -2,6 +2,12 @@ import env # modifies path
 import unittest
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification, ObserverInfo
 
+class TestNotificationName(Notification.Name):
+    test       = "test"
+    test2      = "test2"
+    other      = "other"
+    wrong      = "wrong"
+
 class TestNotificationCenter(unittest.TestCase):
     def setUp(self):
         self.postedUserInfo = None
@@ -15,37 +21,37 @@ class TestNotificationCenter(unittest.TestCase):
 
     def testSingletonCanPost(self):
         nc = NotificationCenter()
-        nc.postNotification("testNotification", self)
+        nc.postNotification(TestNotificationName.test, self)
 
     def testAddObserver(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName="testNotification")
+        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
 
     def testAddObserverCount(self):
         nc = NotificationCenter()
         self.assertEqual(nc.observersCount(), 0)
-        nc.addObserver(observer=self, method=self.handle, notificationName="testNotification")
+        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
         self.assertEqual(nc.observersCount(), 1)
 
     def testObserverInfo(self):
         nc = NotificationCenter()
-        observer = ObserverInfo(observer=self, method=self.handle, notificationName="test", observedObject=nc)
+        observer = ObserverInfo(observer=self, method=self.handle, notificationName=TestNotificationName.test, observedObject=nc)
         
         self.assertTrue(observer.matches(ObserverInfo(observer=self)))
-        self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName="test")))
+        self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=TestNotificationName.test)))
         self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=None)))
-        self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName="test", observedObject=nc)))
+        self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=TestNotificationName.test, observedObject=nc)))
         self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=None, observedObject=nc)))
 
         self.assertFalse(observer.matches(ObserverInfo(observer=nc)))
-        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName="test", observedObject=nc)))
-        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName="other", observedObject=nc)))
-        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName="other", observedObject=None)))
-        self.assertFalse(observer.matches(ObserverInfo(observer=self, notificationName="other", observedObject=None)))
+        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName=TestNotificationName.test, observedObject=nc)))
+        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName=TestNotificationName.other, observedObject=nc)))
+        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName=TestNotificationName.other, observedObject=None)))
+        self.assertFalse(observer.matches(ObserverInfo(observer=self, notificationName=TestNotificationName.other, observedObject=None)))
 
     def testAddObserverRemoveObserver(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName="testNotification")
+        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
         self.assertEqual(nc.observersCount(), 1)
         nc.removeObserver(observer=self)
         self.assertEqual(nc.observersCount(), 0)
@@ -58,24 +64,24 @@ class TestNotificationCenter(unittest.TestCase):
 
     def testAddObserverAnySenderAndPostithObject(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName="testNotification")
-        nc.postNotification(notificationName="testNotification", notifyingObject=self)
+        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
+        nc.postNotification(notificationName=TestNotificationName.test, notifyingObject=self)
         self.assertTrue(self.notificationReceived)
 
         nc.removeObserver(self)
 
     def testAddObserverAnySenderAndPostWithUserInfo(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName="testNotification")
-        nc.postNotification(notificationName="testNotification", notifyingObject=self, userInfo="1234")
+        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
+        nc.postNotification(notificationName=TestNotificationName.test, notifyingObject=self, userInfo="1234")
         self.assertTrue(self.notificationReceived)
         self.assertEqual(self.postedUserInfo, "1234")
         nc.removeObserver(self)
 
     def testAddObserverWrongNotification(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName="testWrong")
-        nc.postNotification(notificationName="testNotification", notifyingObject=self, userInfo="1234")
+        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.wrong)
+        nc.postNotification(notificationName=TestNotificationName.test, notifyingObject=self, userInfo="1234")
         self.assertFalse(self.notificationReceived)
         self.assertNotEqual(self.postedUserInfo, "1234")
         nc.removeObserver(self)
@@ -83,8 +89,8 @@ class TestNotificationCenter(unittest.TestCase):
     def testAddObserverWrongSender(self):
         someObject = NotificationCenter()
         nc = NotificationCenter()
-        nc.addObserver(self, method=self.handle, notificationName="testNotification", observedObject=someObject)
-        nc.postNotification(notificationName="testNotification", notifyingObject=self, userInfo="1234")
+        nc.addObserver(self, method=self.handle, notificationName=TestNotificationName.test, observedObject=someObject)
+        nc.postNotification(notificationName=TestNotificationName.test, notifyingObject=self, userInfo="1234")
         self.assertFalse(self.notificationReceived)
         self.assertNotEqual(self.postedUserInfo, "1234")
         nc.removeObserver(self)
@@ -92,26 +98,26 @@ class TestNotificationCenter(unittest.TestCase):
 
     def testAddObserverNoDuplicates(self):
         nc = NotificationCenter()
-        nc.addObserver(self, self.handle, "testNotification", None)
-        nc.addObserver(self, self.handle, "testNotification", None)
+        nc.addObserver(self, self.handle, TestNotificationName.test, None)
+        nc.addObserver(self, self.handle, TestNotificationName.test, None)
         self.assertEqual(nc.observersCount(), 1)
 
     def testAddObserverNoDuplicates2(self):
         nc = NotificationCenter()
-        nc.addObserver(self, self.handle, "testNotification", None)
-        nc.addObserver(self, self.handle, "testNotification2", None)
+        nc.addObserver(self, self.handle, TestNotificationName.test, None)
+        nc.addObserver(self, self.handle, TestNotificationName.test2, None)
         self.assertEqual(nc.observersCount(), 2)
 
     def testAddObserverNoDuplicates3(self):
         nc = NotificationCenter()
-        nc.addObserver(self, self.handle, "testNotification", None)
-        nc.addObserver(self, self.handle, "testNotification", nc)
+        nc.addObserver(self, self.handle, TestNotificationName.test, None)
+        nc.addObserver(self, self.handle, TestNotificationName.test, nc)
         self.assertEqual(nc.observersCount(), 1)
 
     def testRemoveIncorrectObject(self):
         nc = NotificationCenter()
         someObject = NotificationCenter()
-        nc.addObserver(self, self.handle, "testNotification", someObject)
+        nc.addObserver(self, self.handle, TestNotificationName.test, someObject)
         nc.removeObserver(someObject)
         self.assertEqual(nc.observersCount(), 1)
 

--- a/hardwarelibrary/tests/testNotificationCenter.py
+++ b/hardwarelibrary/tests/testNotificationCenter.py
@@ -1,8 +1,9 @@
 import env # modifies path
 import unittest
+from enum import Enum
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification, ObserverInfo
 
-class TestNotificationName(Notification.Name):
+class TestNotificationName(Enum):
     test       = "test"
     test2      = "test2"
     other      = "other"

--- a/hardwarelibrary/tests/testPhysicalDevice.py
+++ b/hardwarelibrary/tests/testPhysicalDevice.py
@@ -62,6 +62,7 @@ class BaseTestCases:
             self.assertIsNone(self.notificationReceived)
             self.device.initializeDevice()
             self.assertIsNotNone(self.notificationReceived)
+            self.assertEqual(self.notificationReceived.name, PhysicalDeviceNotification.willInitializeDevice)
             nc.removeObserver(self)
 
         def testPostNotificationDidInitialize(self):

--- a/hardwarelibrary/tests/testPhysicalDevice.py
+++ b/hardwarelibrary/tests/testPhysicalDevice.py
@@ -3,9 +3,10 @@ import unittest
 import time
 from threading import Thread, Lock
 import numpy as np
-from physicaldevice import PhysicalDevice, DeviceState
+from physicaldevice import PhysicalDevice, DeviceState, PhysicalDeviceNotification
 from hardwarelibrary.motion import DebugLinearMotionDevice
 from hardwarelibrary.motion import SutterDevice
+from hardwarelibrary.notificationcenter import NotificationCenter, Notification
 
 class DebugPhysicalDevice(PhysicalDevice):
     def __init__(self):
@@ -26,6 +27,7 @@ class BaseTestCases:
         def setUp(self):
             self.device = None
             self.isRunning = False
+            self.notificationReceived = None
 
         def testIsRunning(self):
             self.assertFalse(self.isRunning)
@@ -54,6 +56,42 @@ class BaseTestCases:
                 self.device.shutdownDevice()
                 self.assertTrue(self.device.state == DeviceState.Unrecognized)
 
+        def testPostNotificationWillInitialize(self):
+            nc = NotificationCenter()
+            nc.addObserver(observer=self, method=self.handle, notificationName=PhysicalDeviceNotification.willInitializeDevice, observedObject=self.device)
+            self.assertIsNone(self.notificationReceived)
+            self.device.initializeDevice()
+            self.assertIsNotNone(self.notificationReceived)
+            nc.removeObserver(self)
+
+        def testPostNotificationDidInitialize(self):
+            nc = NotificationCenter()
+            nc.addObserver(observer=self, method=self.handle, notificationName=PhysicalDeviceNotification.didInitializeDevice, observedObject=self.device)
+            self.assertIsNone(self.notificationReceived)
+            self.device.initializeDevice()
+            self.assertIsNotNone(self.notificationReceived)
+            nc.removeObserver(self)
+
+        def testPostNotificationWillShutdown(self):
+            nc = NotificationCenter()
+            nc.addObserver(observer=self, method=self.handle, notificationName=PhysicalDeviceNotification.willShutdownDevice, observedObject=self.device)
+            self.assertIsNone(self.notificationReceived)
+            self.device.initializeDevice()
+            self.device.shutdownDevice()
+            self.assertIsNotNone(self.notificationReceived)
+            nc.removeObserver(self)
+
+        def testPostNotificationDidShutdown(self):
+            nc = NotificationCenter()
+            nc.addObserver(observer=self, method=self.handle, notificationName=PhysicalDeviceNotification.didShutdownDevice, observedObject=self.device)
+            self.assertIsNone(self.notificationReceived)
+            self.device.initializeDevice()
+            self.device.shutdownDevice()
+            self.assertIsNotNone(self.notificationReceived)
+            nc.removeObserver(self)
+
+        def handle(self, notification):
+            self.notificationReceived = notification
 
 class TestDebugPhysicalDevice(BaseTestCases.TestPhysicalDeviceBase):
     def setUp(self):
@@ -87,7 +125,6 @@ class TestSutterPhysicalDevice(BaseTestCases.TestPhysicalDeviceBase):
     def setUp(self):
         super().setUp()
         self.device = SutterDevice(serialNumber="debug")
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/hardwarelibrary/tests/testPhysicalDevice.py
+++ b/hardwarelibrary/tests/testPhysicalDevice.py
@@ -3,7 +3,7 @@ import unittest
 import time
 from threading import Thread, Lock
 import numpy as np
-from physicaldevice import PhysicalDevice, DeviceState, PhysicalDeviceNotification
+from hardwarelibrary.physicaldevice import PhysicalDevice, DeviceState, PhysicalDeviceNotification
 from hardwarelibrary.motion import DebugLinearMotionDevice
 from hardwarelibrary.motion import SutterDevice
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification


### PR DESCRIPTION
It is safer and easier to use Enum for notifications.  It replaces strings, which are not clear and safe (ie. typos).
User must declare their notification names as Enums, if not an exception will be raised.

Important note in the process:
We cannot create a Name subclass of Enum and use it as an argument for name by having users create a subclass of Name (like in Swift).
https://stackoverflow.com/questions/33679930/how-to-extend-python-enum

So we simply request people to use Enum as their base class, it's ok and using the Enum as the key in the dictionary will work (contrary to when it was a subclass).