### PR TITLE
Removing numpy int32

### DIFF
--- a/hardwarelibrary/motion/linearmotiondevice.py
+++ b/hardwarelibrary/motion/linearmotiondevice.py
@@ -1,10 +1,9 @@
 from hardwarelibrary.physicaldevice import *
 from hardwarelibrary.notificationcenter import NotificationCenter
-import numpy as np
 
 class LinearMotionDevice(PhysicalDevice):
 
-    def __init__(self, serialNumber:str, productId:np.uint32, vendorId:np.uint32):
+    def __init__(self, serialNumber:str, productId:int, vendorId:int):
         super().__init__(serialNumber, productId, vendorId)
         self.x = None
         self.y = None

--- a/hardwarelibrary/motion/sutterdevice.py
+++ b/hardwarelibrary/motion/sutterdevice.py
@@ -6,7 +6,6 @@ from hardwarelibrary.communication.serialport import SerialPort
 from hardwarelibrary.communication.commands import DataCommand
 from hardwarelibrary.communication.debugport import DebugPort
 
-import numpy as np
 import re
 import time
 from struct import *

--- a/hardwarelibrary/physicaldevice.py
+++ b/hardwarelibrary/physicaldevice.py
@@ -1,7 +1,6 @@
+from hardwarelibrary.notificationcenter import NotificationCenter
 from enum import Enum, IntEnum
 import typing
-import numpy as np
-from hardwarelibrary.notificationcenter import NotificationCenter
 
 class DeviceState(IntEnum):
     Unconfigured = 0 # Dont know anything
@@ -9,14 +8,13 @@ class DeviceState(IntEnum):
     Recognized = 2   # Initialization has succeeded, but currently shutdown
     Unrecognized = 3 # Initialization failed
 
-
 class PhysicalDevice:
     class UnableToInitialize(Exception):
         pass
     class UnableToShutdown(Exception):
         pass
 
-    def __init__(self, serialNumber:str, productId:np.uint32, vendorId:np.uint32):
+    def __init__(self, serialNumber:str, productId:int, vendorId:int):
         self.vendorId = vendorId
         self.productId = productId
         self.serialNumber = serialNumber

--- a/hardwarelibrary/sources/cobolt.py
+++ b/hardwarelibrary/sources/cobolt.py
@@ -2,7 +2,6 @@ from hardwarelibrary.physicaldevice import *
 from hardwarelibrary.communication import *
 from .lasersourcedevice import LaserSourceDevice
 
-import numpy as np
 import re
 import time
 from threading import Thread, RLock
@@ -13,7 +12,7 @@ class CoboltCantTurnOnWithAutostartOn(Exception):
 class CoboltDevice(PhysicalDevice, LaserSourceDevice):
 
     def __init__(self, bsdPath=None, portPath=None, serialNumber: str = None,
-                 productId: np.uint32 = None, vendorId: np.uint32 = None):
+                 productId: int = None, vendorId: int = None):
 
         self.laserPower = 0
         self.requestedPower = 0

--- a/hardwarelibrary/tests/testPhysicalDevice.py
+++ b/hardwarelibrary/tests/testPhysicalDevice.py
@@ -2,7 +2,6 @@ import env # modifies path
 import unittest
 import time
 from threading import Thread, Lock
-import numpy as np
 from physicaldevice import PhysicalDevice, DeviceState
 from hardwarelibrary.motion import DebugLinearMotionDevice
 from hardwarelibrary.motion import SutterDevice


### PR DESCRIPTION
No need for numpy just for an int32. No big deal to use Python's `Int`.