### PR TITLE
SutterDevice can now get its url from SerialPort

### DIFF
--- a/README-7-Sutter-ROE-200.md
+++ b/README-7-Sutter-ROE-200.md
@@ -4,7 +4,7 @@ Do not use yet.
 
 
 
-An example: Sutter ROE-200
+## An example: Sutter ROE-200
 
 Let's look at a classic from microscopy and neuroscience, the MPC-385 XYZ stage from Sutter Instruments with its ROE-200 controller. The manual is available [here](https://github.com/DCC-Lab/PyHardwareLibrary/blob/cd7bf0cf6256ba4dbc6eb26f0657c0db59b35848/hardwarelibrary/manuals/MPC-325_OpMan.pdf) or on their web site, and it is sufficiently detailed for us (it also has a few omissions that we will find).  When we connect the device, we can inspect its **USB Descriptors**. We then find out that the idVendor is 4930, the idProduct is 1. We can pick a USB configuration, pick a USB interface, then the inspection of the endpoint descriptors tells us it has two endpoints: one IN, one OUT. 
 

--- a/README-7-Sutter-ROE-200.md
+++ b/README-7-Sutter-ROE-200.md
@@ -1,0 +1,384 @@
+# This document is incomplete and contains error
+
+Do not use yet.
+
+
+
+An example: Sutter ROE-200
+
+Let's look at a classic from microscopy and neuroscience, the MPC-385 XYZ stage from Sutter Instruments with its ROE-200 controller. The manual is available [here](https://github.com/DCC-Lab/PyHardwareLibrary/blob/cd7bf0cf6256ba4dbc6eb26f0657c0db59b35848/hardwarelibrary/manuals/MPC-325_OpMan.pdf) or on their web site, and it is sufficiently detailed for us (it also has a few omissions that we will find).  When we connect the device, we can inspect its **USB Descriptors**. We then find out that the idVendor is 4930, the idProduct is 1. We can pick a USB configuration, pick a USB interface, then the inspection of the endpoint descriptors tells us it has two endpoints: one IN, one OUT. 
+
+```python
+device = usb.core.find(idVendor=4930, idProduct=1) # Sutter Instruments has idVendor 4930 or 0x1342
+if device is None:
+    raise IOError("Can't find device")
+
+device.set_configuration()                         # first configuration
+configuration = device.get_active_configuration()  # get the active configuration
+interface = configuration[(0,0)]                   # pick the first interface (0) with no alternate (0)
+
+outputEndpoint = interface[0]                      # First endpoint is the output endpoint
+inputEndpoint = interface[1]                       # Second endpoint is the input endpoint
+
+```
+
+### Commands
+
+Once we have dientified the device, we need to send commands and read replies.  Please note that this is not possible with `PyUSB` because we need to send "serial" commands to the FDTI chips. Typically, the Sutter ROE-200 will be recognized by the FTDI driver, but on Big Sur (Summer 2021), their driver was modified and does not recognize it yet.  But we can use PyFTDI (which itself uses PyUSB) to send our commands to the Sutter Device.
+
+It is a very simple device, because it has a very limited set of commands it accepts. It can **move**, it can tell you its **position**.  There are other commands, but they will not be critical here and we will not implement them.
+
+<img src="/Users/dccote/GitHub/PyHardwareLibrary/README.assets/image-20210415195905341.png" alt="image-20210415195905341" style="zoom:25%;" /><img src="/Users/dccote/GitHub/PyHardwareLibrary/README.assets/image-20210415195013040.png" alt="image-20210415195013040" style="zoom: 24%;" />
+
+Let's look at the anatomy of the **Get Current Position** command: it is the `C` character (which has an ASCII code of 0x43), and the documentation says that the total number of bytes is two for the command. Reading other versions of the manual and discussing with Sutter tells us that all commands are followed by a carriage return `\r`  (ASCII character 0x0d). So if we send this command to the device, it should reply with its position.
+
+The reply will be 13 bytes: it will consist of 3 values for X, Y and Z coordinates, encoded as `signed long integers` (32 bits or 4 bytes).  Closing this will be the carriage return `\r`, indicated at the top of the next page, for a total of 13 bytes.
+
+### Sending GetPosition command
+
+Python has `byte` and `bytearray` objects. The `b` indicates that the string of text must be interpreted as bytes. We pick the OUT endpoint, and send the command with:
+
+```python
+commandBytes = bytearray(b'C\r')
+outputEndpoint.write(commandBytes)
+```
+
+### Reading GetPosition reply
+
+We read the 13 bytes from the input endpoint:
+
+```python
+replyBytes = inputEndPoint.read(size_or_buffer=13)
+```
+
+If everything goes well, the last byte will be the character `\r`.  We know from the documentation that these 13 bytes represent 3 signed long integers and a character. Python has a function to `pack` and `unpack` this data. The function is described [here](https://docs.python.org/3/library/struct.html), and the format that corresponds to our binary data is `<lllc`: Little-endian (<), three long ('l') and a letter ('c') 
+
+```python
+x,y,z, lastChar = unpack('<lllc', replyBytes)
+
+if lastChar == b'\r':
+    print("The position is {0}, {1}, {2}".format(x,y,z))
+else:
+    print('Error in reply: last character not 0x0d')
+   
+```
+
+### Sending MovePosition command
+
+To move the stage to a different position, we need to encode (i.e. `pack`) the positions we want into binary data. This is done with:
+
+```python
+# We already have the position in x,y and z. We will move a bit from there.
+commandBytes = pack('<clllc', ('M', x+10, y+10, z+10, '\r'))
+outputEndpoint.write(commandBytes)
+```
+
+### Reading MovePosition reply
+
+The stage will move and will send a `\r` when done, as per the documentation.
+
+```python
+replyBytes = inputEndPoint.read(size_or_buffer=1)
+lastChar = unpack('<c', replyBytes)
+
+if lastChar != b'\r':
+    print('Error: incorrect reply character')
+    
+```
+
+The complete code, repackaged with functions, is available here:
+
+```python
+# this file is called sutter.py
+import usb.core
+import usb.util
+from struct import *
+
+device = usb.core.find(idVendor=4930, idProduct=1) # Sutter Instruments has idVendor 4930 or 0x1342
+if device is None:
+    raise IOError("Can't find device")
+
+device.set_configuration()                         # first configuration
+configuration = device.get_active_configuration()  # get the active configuration
+interface = configuration[(0,0)]                   # pick the first interface (0) with no alternate (0)
+
+outputEndpoint = interface[0]                      # First endpoint is the output endpoint
+inputEndpoint = interface[1]                       # Second endpoint is the input endpoint
+
+def position() -> (int,int,int):
+    commandBytes = bytearray(b'C\r')
+    outputEndpoint.write(commandBytes)
+
+    replyBytes = inputEndPoint.read(size_or_buffer=13)
+    x,y,z, lastChar = unpack('<lllc', replyBytes)
+
+    if lastChar == b'\r':
+        return (x,y,z)
+    else:
+        return None
+  
+def move(position) -> bool:
+    x,y,z  = position
+    commandBytes = pack('<clllc', ('M', x, y, z, '\r'))
+    outputEndpoint.write(commandBytes)
+    
+    replyBytes = inputEndPoint.read(size_or_buffer=1)
+		lastChar = unpack('<c', replyBytes)
+
+    if lastChar != b'\r':
+        return True
+    
+    return False
+    
+```
+
+## Encapsulating the USB device in a class
+
+We may have communicated with the device, but it would still be tedious to use:
+
+1. We will need to include this code in any Python script that manipulates the device
+2. We have variables floating around (`device`, `interface`, `inputEndpoint`, `outputEndpoint`), they will prevent us from using them again (they are global).
+3. We have to keep track of the position ourselves and convert to microns manually: currently the position is in micro steps
+4. Our error management is minimal.  For instance, what if the device does not reply in time? 
+
+It would be preferable to have a single object (i.e. the sutter device), and that that object 1) manages the communication without us, 2) responds to `moveTo` and `position`, 3) keeps track of its position, manage it and really, isolates us from the details? We don't really care that it communicates through USB and that there are "endpoints".  All we want is for the device to **move** and tell us **its position**.  We can therefore create a `SutterDevice` class that will do that: *a class hides the details away inside an object that keeps the variables and the functions to operate on these variables together.*
+
+```python
+# This file is called bettersutter.py
+import usb.core
+import usb.util
+from struct import *
+
+class SutterDevice:
+    def __init_(self):
+      self.device = usb.core.find(idVendor=4930, idProduct=1) 
+			if device is None:
+    		raise IOError("Can't find Sutter device")
+
+      self.device.set_configuration()        # first configuration
+      self.configuration = self.device.get_active_configuration()  # get the active configuration
+      self.interface = self.configuration[(0,0)]  # pick the first interface (0) with no alternate (0)
+
+      self.outputEndpoint = self.interface[0] # First endpoint is the output endpoint
+      self.inputEndpoint = self.interface[1]  # Second endpoint is the input endpoint
+      
+      self.microstepsPerMicrons = 16
+
+    def positionInMicrosteps(self) -> (int,int,int):
+      commandBytes = bytearray(b'C\r')
+      outputEndpoint.write(commandBytes)
+
+      replyBytes = inputEndPoint.read(size_or_buffer=13)
+      x,y,z, lastChar = unpack('<lllc', replyBytes)
+
+      if lastChar == b'\r':
+        return (x,y,z)
+      else:
+        return None
+  
+  	def moveInMicrostepsTo(self, position) -> bool:
+      x,y,z  = position
+      commandBytes = pack('<clllc', ('M', x, y, z, '\r'))
+      outputEndpoint.write(commandBytes)
+
+      replyBytes = inputEndPoint.read(size_or_buffer=1)
+      lastChar = unpack('<c', replyBytes)
+
+      if lastChar != b'\r':
+        return True
+
+      return False
+    
+    def position(self) -> (float, float, float):
+			position = self.positionInMicrosteps()
+      if position is not None:
+          return (position[0]/self.microstepsPerMicrons, 
+                  position[1]/self.microstepsPerMicrons,
+                  position[2]/self.microstepsPerMicrons)
+      else:
+          return None
+      
+  	def moveTo(self, position) -> bool:
+      x,y,z  = position
+      positionInMicrosteps = (x*self.microstepsPerMicrons, 
+                              y*self.microstepsPerMicrons,
+                              z*self.microstepsPerMicrons)
+      
+      return self.moveInMicrostepsTo( positionInMicrosteps)
+
+    def moveBy(self, delta) -> bool:
+      dx,dy,dz  = delta
+      position = self.position()
+      if position is not None:
+          x,y,z = position
+          return self.moveTo( (x+dx, y+dy, z+dz) )
+			return True
+
+if __name__ == "__main__":
+    device = SutterDevice()
+
+    x,y,z = device.position()
+    device.moveTo( (x+10, y+10, z+10) )
+    device.moveBy( (-10, -10, -10) )
+```
+
+Notice how:
+
+1. We don't know the implementation details, yet it fully responds to our needs: it can move and tell us where it is.
+2. We can make other convenience functions that make use of the two key functions (`moveInMicrostepsTo` and `positionInMicrosteps`). For instance, we can create a `moveBy` function that will take care of getting the position for us then increase it and send the move command.
+3. We still may have problems if the communication with the device does not go as planned.
+4. If the device is not connected, or not on, the code will fail with no other options than to restart the program.
+
+
+
+### Robust encapsulation
+
+We can still improve things. In this version:
+
+1. The device does not need to be connected for the `SutterDevice` to be created.
+
+2. The write and read functions are limited to two functions that can manage any errors gracefully: if there is any error, we shutdown everything and will initialize the device again on the next call.
+
+3. Minimal docstrings (Python inline help) is available.
+
+    
+
+```python
+# This file is called bestsutter.py
+import usb.core
+import usb.util
+from struct import *
+
+class SutterDevice:
+    def __init_(self):
+      """
+      SutterDevice represents a XYZ stage.  
+      """
+      self.device = None
+      self.configuration = None
+      self.interface = None
+      self.outputEndpoint = None
+      self.inputEndpoint = None
+     
+      self.microstepsPerMicrons = 16
+
+    def initializeDevice(self):
+      """
+      We do a late initialization: if the device is not present at creation, it can still be
+      initialized later.
+      """
+
+      if self.device is not None:
+        return
+      
+      self.device = usb.core.find(idVendor=4930, idProduct=1) 
+      if self.device is None:
+        raise IOError("Can't find Sutter device")
+
+      self.device.set_configuration()        # first configuration
+      self.configuration = self.device.get_active_configuration()  # get the active configuration
+      self.interface = self.configuration[(0,0)]  # pick the first interface (0) with no alternate (0)
+
+      self.outputEndpoint = self.interface[0] # First endpoint is the output endpoint
+      self.inputEndpoint = self.interface[1]  # Second endpoint is the input endpoint
+    
+    def shutdownDevice(self):
+      """
+      If the device fails, we shut everything down. We should probably flush the buffers also.
+      """
+      
+      self.device = None
+      self.configuration = None
+      self.interface = None
+      self.outputEndpoint = None
+      self.inputEndpoint = None
+      
+    def sendCommand(self, commandBytes):
+      """ The function to write a command to the endpoint. It will initialize the device 
+      if it is not alread initialized. On failure, it will warn and shutdown."""
+      try:
+        if self.outputEndpoint is None:
+          self.initializeDevice()
+          
+        self.outputEndpoint.write(commandBytes)
+      except Exception as err:
+        print('Error when sending command: {0}'.format(err))
+        self.shutdownDevice()
+    
+    def readReply(self, size, format) -> tuple:
+      """ The function to read a reply from the endpoint. It will initialize the device 
+      if it is not already initialized. On failure, it will warn and shutdown. 
+      It will unpack the reply into a tuple, and will remove the b'\r' that is always present.
+      """
+
+      try:
+        if self.outputEndpoint is None:
+          self.initializeDevice()
+
+        replyBytes = inputEndPoint.read(size_or_buffer=size)
+        theTuple = unpack(format, replyBytes)
+        if theTuple[-1] != b'\r':
+           raise RuntimeError('Invalid communication')
+        return theTuple[:-1] # We remove the last character
+      except Exception as err:
+        print('Error when reading reply: {0}'.format(err))
+        self.shutdownDevice()
+        return None
+      
+    def positionInMicrosteps(self) -> (int,int,int):
+      """ Returns the position in microsteps """
+      commandBytes = bytearray(b'C\r')
+      self.sendCommand(commandBytes)
+      return self.readReply(size=13, format='<lllc')
+  
+    def moveInMicrostepsTo(self, position):
+      """ Move to a position in microsteps """
+      x,y,z  = position
+      commandBytes = pack('<clllc', ('M', x, y, z, '\r'))
+      self.sendCommand(commandBytes)
+      self.readReply(size=1, format='<c')
+    
+    def position(self) -> (float, float, float):
+      """ Returns the position in microns """
+
+      position = self.positionInMicrosteps()
+      if position is not None:
+          return (position[0]/self.microstepsPerMicrons, 
+                  position[1]/self.microstepsPerMicrons,
+                  position[2]/self.microstepsPerMicrons)
+      else:
+          return None
+      
+    def moveTo(self, position):
+      """ Move to a position in microns """
+
+      x,y,z  = position
+      positionInMicrosteps = (x*self.microstepsPerMicrons, 
+                              y*self.microstepsPerMicrons,
+                              z*self.microstepsPerMicrons)
+      
+      self.moveInMicrostepsTo( positionInMicrosteps)
+
+    def moveBy(self, delta) -> bool:
+      """ Move by a delta displacement (dx, dy, dz) from current position in microns """
+
+      dx,dy,dz  = delta
+      position = self.position()
+      if position is not None:
+          x,y,z = position
+          self.moveTo( (x+dx, y+dy, z+dz) )
+
+if __name__ == "__main__":
+    device = SutterDevice()
+
+    x,y,z = device.position()
+    device.moveTo( (x+10, y+10, z+10) )
+    device.moveBy( (-10, -10, -10) )
+```
+
+We have made significant progress, but there are still problems or at least areas that can be improved:
+
+1. The code above has not been fully tested.  How do we test this? Is it necessary? The solution will be **Unit Testing**. *Hint*: when we do, we will learn that the **move** command actually sends a 0x00 byte at a regular interval when the move is taking a long time. This is not in the documentation but it sure is in the device. 
+2. In fact, the code above was not tested at all, because I don't have the device on my computer, it is only in the lab and I wrote the code from home.  It would be nice to be able to test even without the device connected, especially when we integrate this code into other larger projects. The solution will be a mock (i.e. fake) **DebugSutterDeviceUSBPort** that behaves like the real thing. This will require abstracting away the **USBPort** itself.
+3. Error management is not easy with hardware devices. They can fail, they can be disconnected, they can be missing, the firmware in the device can be upgraded, etc... If the command times out, what are you supposed to do? Can you recover? The solution is a more general class **PhysicalDevice** that can manage these aspects, while offering enough flexibility to adapt to any type of device. The is the strategy behind **PyHardwareLibrary**.
+4. We are putting a lot of work in this Sutter Instrument stage, but what if it breaks and your supervisor purchases or borrows another device (say a Prior)?  Should you change all your code? It is, after all, just another linear stage. The solution to this is a **LinearMotionDevice** base class that will offer a uniform set of functions to move and get the position, without knowing any details about the device itself. This way, the **SutterDevice** will inherit from **LinearMotionDevice**, and a new **PriorDevice** would also inherit from it and could act as a perfect substitute. This approach, which requires time investment in the short term, will limit the impact of any change in the future.  You can take a look at [**OISpectrometer**](https://github.com/DCC-Lab/PyHardwareLibrary/blob/c6fa50b932945388bb5bfce443669158275c5db4/hardwarelibrary/spectrometers/oceaninsight.py) in the PyHardwareLibrary for an example, where two spectrometers can be used interchangeably since they both derive from OISpectrometer, which can return a **USB2000** or a **USB4000** depending on what is connected.

--- a/hardwarelibrary/communication/serialport.py
+++ b/hardwarelibrary/communication/serialport.py
@@ -115,22 +115,31 @@ class SerialPort(CommunicationPort):
 
     @classmethod
     def ftdiPorts(cls):
-        portList = StringIO()
-        Ftdi.show_devices()
-        everything = portList.getvalue()
+        # Ftdi.show_devices("ftdi:///?", out=portList)
+        # everything = portList.getvalue()
         # print(everything)
         urls = []
-        for someText in everything.split():
-            match = re.match("ftdi://(.+):(.+):(.+)/",someText,re.IGNORECASE)
-            if match is not None:
-                groups = match.groups()
-                thePort = ListPortInfo(device="")
-                thePort.vid = groups[0]
-                thePort.pid = groups[1]
-                thePort.serial_number = groups[2]
-                thePort.device = someText
+        # for someText in everything.split():
+        #     match = re.match("ftdi://(.+):(.+):(.+)/",someText,re.IGNORECASE)
+        #     if match is not None:
+        #         groups = match.groups()
+        #         thePort = ListPortInfo(device="")
+        #         thePort.vid = groups[0]
+        #         thePort.pid = groups[1]
+        #         thePort.serial_number = groups[2]
+        #         thePort.device = someText
 
-                urls.append(thePort)
+        #         urls.append(thePort)
+
+        # FIXME: for some reason, I can't get the Sutter URls above and I must handcode the following.
+        sutterDevices = Ftdi.list_devices(url="ftdi://4930:1/1")
+        for device, address in sutterDevices:
+            thePort = ListPortInfo(device="")
+            thePort.vid = device.vid
+            thePort.pid = device.pid
+            thePort.serial_number = device.sn
+            thePort.device = "ftdi://{0}:{1}:{2}/{3}".format(device.vid, device.pid, device.sn, address)
+            urls.append(thePort)
 
         return urls
 

--- a/hardwarelibrary/motion/sutterdevice.py
+++ b/hardwarelibrary/motion/sutterdevice.py
@@ -10,6 +10,8 @@ import re
 import time
 from struct import *
 
+from pyftdi.ftdi import Ftdi #FIXME: should not be here.
+
 class SutterDevice(LinearMotionDevice):
 
     def __init__(self, serialNumber: str = None):
@@ -37,7 +39,11 @@ class SutterDevice(LinearMotionDevice):
             if self.serialNumber == "debug":
                 self.port = self.DebugSerialPort()
             else:
-                self.port = SerialPort(portPath="ftdi://0x1342:0x0001:SI8YCLBE/1")
+                portPath = SerialPort.matchAnyPort(idVendor=self.vendorId, idProduct=self.productId, serialNumber=self.serialNumber)
+                if portPath is None:
+                    raise PhysicalDevice.UnableToInitialize("No Sutter Device connected")
+
+                self.port = SerialPort(portPath=portPath)
                 self.port.open(baudRate=128000, timeout=10)
 
             if self.port is None:

--- a/hardwarelibrary/tests/testLinearMotionDevice.py
+++ b/hardwarelibrary/tests/testLinearMotionDevice.py
@@ -9,9 +9,14 @@ from hardwarelibrary.notificationcenter import NotificationCenter
 class BaseTestCases:
     class TestLinearMotionDevice(unittest.TestCase):
         def setUp(self):
-            self.device = None
+            # Set self.device in subclass
             self.willNotificationReceived = False
             self.didNotificationReceived = False
+            self.assertIsNotNone(self.device)
+            self.device.initializeDevice()
+
+        def tearDown(self):
+            self.device.initializeDevice()
 
         def testDevicePosition(self):
             (x, y, z) = self.device.position()
@@ -105,7 +110,7 @@ class BaseTestCases:
         def testPositionNotifications(self):
             NotificationCenter().addObserver(self, method=self.handleDid, notificationName=LinearMotionNotification.didGetPosition)
             (x, y, z) = self.device.position()
-            self.assertTrue(self.didNotificationReceived)        
+            self.assertTrue(self.didNotificationReceived)
             NotificationCenter().removeObserver(self)
 
         def testDeviceMoveNotifications(self):
@@ -154,19 +159,18 @@ class BaseTestCases:
 
 class TestDebugLinearMotionDeviceBase(BaseTestCases.TestLinearMotionDevice):
     def setUp(self):
-        super().setUp()
         self.device = DebugLinearMotionDevice()
+        super().setUp()
 
 class TestDebugSutterDeviceBase(BaseTestCases.TestLinearMotionDevice):
     def setUp(self):
-        super().setUp()
         self.device = SutterDevice("debug")
+        super().setUp()
 
 class TestRealSutterDeviceBase(BaseTestCases.TestLinearMotionDevice):
     def setUp(self):
-        super().setUp()
         self.device = SutterDevice()
-        self.assertIsNotNone(self.device)
+        super().setUp()
 
 if __name__ == '__main__':
     unittest.main()

--- a/hardwarelibrary/tests/testLinearMotionDevice.py
+++ b/hardwarelibrary/tests/testLinearMotionDevice.py
@@ -162,6 +162,11 @@ class TestDebugSutterDeviceBase(BaseTestCases.TestLinearMotionDevice):
         super().setUp()
         self.device = SutterDevice("debug")
 
+class TestRealSutterDeviceBase(BaseTestCases.TestLinearMotionDevice):
+    def setUp(self):
+        super().setUp()
+        self.device = SutterDevice()
+        self.assertIsNotNone(self.device)
 
 if __name__ == '__main__':
     unittest.main()

--- a/hardwarelibrary/tests/testModulePyFTDI.py
+++ b/hardwarelibrary/tests/testModulePyFTDI.py
@@ -10,8 +10,18 @@ import re
 class TestPyFTDIModule(unittest.TestCase):
     def setUp(self):
         portList = StringIO()
+
+        try:
+            idVendor = 4930
+            idProduct = 1
+
+            pyftdi.ftdi.Ftdi.add_custom_product(vid=idVendor, pid=idProduct, pidname='VID {0}: PID {1}'.format(idVendor, idProduct))
+        except Exception as err:
+            print(err)        
+
         Ftdi.show_devices(out=portList)
         self.assertIsNotNone(portList)
+        print("{0}".format(portList.getvalue()))
         if len(portList.getvalue()) == 0:
             raise(unittest.SkipTest("No FTDI connected. Skipping."))
 

--- a/hardwarelibrary/tests/testSutterDevice.py
+++ b/hardwarelibrary/tests/testSutterDevice.py
@@ -11,21 +11,22 @@ import serial
 
 class TestSutterDevice(unittest.TestCase):
     def setUp(self):
-            # pyftdi.ftdi.Ftdi.add_custom_product(vid=4930, pid=1, pidname='Sutter')
         try: 
             self.device = SutterDevice()
             self.device.initializeDevice()
         except:
             self.device = SutterDevice("debug")
             self.device.initializeDevice()
-            #print("Using Debug Sutter device for tests")
         
         self.assertIsNotNone(self.device)
-        # raise(unittest.SkipTest("No FTDI connected. Skipping."))
 
     def tearDown(self):
         self.device.shutdownDevice()
         self.device = None
+
+    def testFTDIMatchPort(self):
+        thePort = SerialPort.matchAnyPort(idVendor=4930, idProduct=1)
+        self.assertIsNotNone(thePort)
 
     def testNativeUnits(self):
         self.assertEqual(self.device.nativeStepsPerMicrons, 16)


### PR DESCRIPTION
SerialPort is the base class for anything related to serial port devices and must be able to provide the list of valid "paths".
The FTDI driver is non-functional on macOS Big Sur for Sutter because the vendor id is not included, so the system does not recognize it.  PyFTDI can therefore be used and it interfaces with PySerial, so it's all good.  

We use SerialPort.matchPorts() to retrieve the full path but for some reason, I am having problems retrieving a Sutter device even after I added the port as a custom product-vendor pair.  I hacked a solution that works for now by finding specifically the Sutter vendorId and productId. It works and Sutter is the only device that PyHardwareLibrary supports and uses the FTDI chip.