### PR TITLE
Fix 10 latent bugs uncovered by static review

### DIFF
--- a/hardwarelibrary/communication/debugport.py
+++ b/hardwarelibrary/communication/debugport.py
@@ -59,8 +59,7 @@ class DebugPort(CommunicationPort):
         self.buffers = [bytearray(),bytearray()]
 
     def readData(self, length, endPoint=None):
-        if endPoint is None:
-            endPointIndex = 0
+        endPointIndex = 0 if endPoint is None else endPoint
 
         with self.portLock:
             time.sleep(self.delay*random.random())
@@ -75,8 +74,7 @@ class DebugPort(CommunicationPort):
         return data
 
     def writeData(self, data, endPoint=None):
-        if endPoint is None:
-            endPointIndex = 0
+        endPointIndex = 0 if endPoint is None else endPoint
 
         with self.portLock:
             self.inputBuffers[endPointIndex].extend(data)

--- a/hardwarelibrary/devicemanager.py
+++ b/hardwarelibrary/devicemanager.py
@@ -93,7 +93,7 @@ class USBDeviceDescriptor:
             return False
         if self.idVendor != device.idVendor:
             return False
-        if re.match(self.serialNumber, device.serialNumber, re.IGNORECASE) is not None:
+        if re.match(self.serialNumber, device.serialNumber, re.IGNORECASE) is None:
             return False
 
         return True

--- a/hardwarelibrary/motion/rotationdevice.py
+++ b/hardwarelibrary/motion/rotationdevice.py
@@ -54,7 +54,7 @@ class DebugRotationDevice(RotationDevice):
         self._debugOrientation = angle
 
     def doMoveBy(self, displacement):
-        self._debugOrientation += angle
+        self._debugOrientation += displacement
 
     def doHome(self):
         self._debugOrientation = 0

--- a/hardwarelibrary/motion/sutterdevice.py
+++ b/hardwarelibrary/motion/sutterdevice.py
@@ -49,7 +49,7 @@ class SutterDevice(LinearMotionDevice):
                 self.port.open(baudRate=128000, timeout=10)
 
             if self.port is None:
-                raise PhysicalDevice.UnableToInitialize("Cannot allocate port {0}".format(self.portPath))
+                raise PhysicalDevice.UnableToInitialize("Cannot allocate port for serial '{0}'".format(self.serialNumber))
 
             self.positionInMicrosteps()
 

--- a/hardwarelibrary/physicaldevice.py
+++ b/hardwarelibrary/physicaldevice.py
@@ -1,7 +1,7 @@
 from enum import Enum, IntEnum
 from threading import Thread, RLock
 
-import hardwarelibrary.utils
+from hardwarelibrary import utils
 from hardwarelibrary.notificationcenter import NotificationCenter
 import typing
 import time

--- a/hardwarelibrary/powermeters/powermeterdevice.py
+++ b/hardwarelibrary/powermeters/powermeterdevice.py
@@ -28,11 +28,5 @@ class PowerMeterDevice(PhysicalDevice):
         self.doSetCalibrationWavelength(wavelength)
         self.doGetCalibrationWavelength()
 
-    def measureAbsolutePower(self):
-        self.doGetAbsolutePower()
-        power = self.absolutePower
-        NotificationCenter().postNotification(PowerMeterNotification.didMeasure, notifyingObject=self, userInfo=power)
-        return power
-
     def doGetStatusUserInfo(self):
         return self.measureAbsolutePower()

--- a/hardwarelibrary/sources/cobolt.py
+++ b/hardwarelibrary/sources/cobolt.py
@@ -6,6 +6,8 @@ import re
 import time
 from threading import Thread, RLock
 
+globalLock = RLock()
+
 class CoboltCantTurnOnWithAutostartOn(Exception):
     pass
 

--- a/hardwarelibrary/sources/cobolt.py
+++ b/hardwarelibrary/sources/cobolt.py
@@ -66,13 +66,14 @@ class CoboltDevice(PhysicalDevice, LaserSourceDevice):
             self.doTurnAutostartOn()
             self.doGetInterlockState()
             self.doGetPower()
-        except Exception as error:
-            if self.port is not None:
-                if self.port.isOpen:
-                    self.port.close()
+        except PhysicalDevice.UnableToInitialize:
+            if self.port is not None and self.port.isOpen:
+                self.port.close()
+            raise
+        except Exception:
+            if self.port is not None and self.port.isOpen:
+                self.port.close()
             raise PhysicalDevice.UnableToInitialize()
-        except PhysicalDeviceUnableToInitialize as error:
-            raise error
         
 
     def doShutdownDevice(self):

--- a/hardwarelibrary/spectrometers/base.py
+++ b/hardwarelibrary/spectrometers/base.py
@@ -147,7 +147,7 @@ class Spectrometer(PhysicalDevice):
        speed, etc...). More spectrometers will be supported in the future.
        Look at the class USB2000 to see what you have to provide to support
        a new spectrometer (it is not that much work, but you need one to test).
-""".format(__file__, ', '.join(Spectrometer.supportedClassNames)))
+""".format(__file__, ', '.join(Spectrometer.supportedClassNames())))
 
         # Well, how about that? This does not work in Windows
         # https://stackoverflow.com/questions/2330245/python-change-text-color-in-shell

--- a/hardwarelibrary/spectrometers/oceaninsight.py
+++ b/hardwarelibrary/spectrometers/oceaninsight.py
@@ -275,7 +275,7 @@ class OISpectrometer(Spectrometer):
                 self.epStatus = self.inputEndpoints[self.epStatusIdx]
 
             self.flushEndpoints()
-            self.sendCommand(b'0x01')
+            self.sendCommand(b'\x01')
             time.sleep(0.1)
             self.getCalibration()
         except Exception as err:


### PR DESCRIPTION
## Summary

Ten targeted fixes for latent bugs found during a static review of `master`. Each commit stands alone with a Problem/Solution body in its message — none are bundled.

| # | Fix | File |
|---|---|---|
| 1 | Inverted serialNumber regex condition prevented USB-disconnect cleanup | `devicemanager.py` |
| 2 | Undefined `globalLock` broke `CoboltDebugSerial` in debug mode | `sources/cobolt.py` |
| 3 | Broad `except Exception` discarded the `UnableToInitialize` message; the follow-up `except` clause referenced an undefined name | `sources/cobolt.py` |
| 4 | `DebugRotationDevice.doMoveBy` used the wrong identifier (`angle` instead of `displacement`) | `motion/rotationdevice.py` |
| 5 | `Spectrometer.showHelp` joined a bound method instead of calling it | `spectrometers/base.py` |
| 6 | Ocean Insight init sent the 4-byte ASCII `b'0x01'` instead of the single byte `b'\x01'` | `spectrometers/oceaninsight.py` |
| 7 | `import hardwarelibrary.utils` didn't bind the short name `utils` used throughout the file | `physicaldevice.py` |
| 8 | `PowerMeterDevice.measureAbsolutePower` was defined twice (duplicate) | `powermeters/powermeterdevice.py` |
| 9 | `DebugPort.readData`/`writeData` left `endPointIndex` unbound on any explicit `endPoint` argument | `communication/debugport.py` |
| 10 | `SutterDevice` formatted an init error with `self.portPath`, which is never set on the instance | `motion/sutterdevice.py` |

No behavior changes for working code paths; all fixes target code that was either dead or already broken.

## Test plan

- [ ] Confirm existing test files still pass: `python3 -m pytest hardwarelibrary/tests/testCommandRecognition.py hardwarelibrary/tests/testTableDrivenDebugPort.py hardwarelibrary/tests/testCommunicationPorts.py hardwarelibrary/tests/testPhysicalDevice.py -v`
- [ ] Exercise the `DeviceManager` disconnect flow at least once (the inverted-match fix #1 is the only one that changes behavior for a currently-working call site)
- [ ] Sanity-check the Cobolt debug path (`portPath="debug"`) — exercises fixes #2 and #3
- [ ] If an Ocean Insight spectrometer is available, confirm `doInitializeDevice` succeeds (fix #6 changes the wire bytes sent during init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)