### PR TITLE
DebugPort: multi-endpoint support + flush()/DebugDataCommand fixes

### DIFF
--- a/hardwarelibrary/communication/debugport.py
+++ b/hardwarelibrary/communication/debugport.py
@@ -4,72 +4,52 @@ import random
 from hardwarelibrary.communication import *
 from threading import Thread, Lock
 
-class DebugDataCommand(Command):
-    def __init__(self, name, dataHexRegex = None, unpackingMask = None, endPoints = (None, None)):
-        Command.__init__(self, name, endPoints=endPoints)
-        self.data : bytearray = data
-        self.dataHexRegex: str = dataHexRegex
-        self.unpackingMask:str = unpackingMask
-
-    def send(self, port) -> bool:
-        try:
-            self.isSent = True
-            nBytes = port.writeData(data=self.data, endPoint=self.endPoints[0])
-            if self.replyDataLength > 0:
-                self.reply = port.readData(length=self.replyDataLength)
-            elif self.replyHexRegex is not None:
-                raise NotImplementedError("DataCommand reply pattern not implemented")
-                # self.reply = port.readData(length=self.replyDataLength)
-            self.isSentSuccessfully = True
-        except Exception as err:
-            
-            self.exceptions.append(err)
-            self.isSentSuccessfully = False
-            raise(err)
-
-        return False
-
 class DebugPort(CommunicationPort):
-    def __init__(self, delay=0):
-        self.inputBuffers = [bytearray()]
-        self.outputBuffers = [bytearray()]
+    def __init__(self, delay=0, numberOfEndPoints=1):
+        self.inputBuffers = [bytearray() for _ in range(numberOfEndPoints)]
+        self.outputBuffers = [bytearray() for _ in range(numberOfEndPoints)]
         self.delay = delay
+        self.defaultTimeout = 500
         self._isOpen = False
         super(DebugPort, self).__init__()
 
     @property
     def isOpen(self):
-        return self._isOpen    
+        return self._isOpen
 
     def open(self):
         if self._isOpen:
-            raise Exception()
+            raise Exception("Port already open")
 
         self._isOpen = True
-        return
 
     def close(self):
         self._isOpen = False
-        return
 
     def bytesAvailable(self, endPoint=0):
-        return len(self.outputBuffers[endPoint])
+        endPointIndex = endPoint if endPoint is not None else 0
+        return len(self.outputBuffers[endPointIndex])
 
     def flush(self):
-        self.buffers = [bytearray(),bytearray()]
+        for i in range(len(self.inputBuffers)):
+            self.inputBuffers[i] = bytearray()
+        for i in range(len(self.outputBuffers)):
+            self.outputBuffers[i] = bytearray()
 
     def readData(self, length, endPoint=None):
         endPointIndex = 0 if endPoint is None else endPoint
 
         with self.portLock:
-            time.sleep(self.delay*random.random())
+            if self.delay > 0:
+                time.sleep(self.delay * random.random())
+
             data = bytearray()
-            for i in range(0, length):
+            for i in range(length):
                 if len(self.outputBuffers[endPointIndex]) > 0:
                     byte = self.outputBuffers[endPointIndex].pop(0)
                     data.append(byte)
                 else:
-                    raise CommunicationReadTimeout("Unable to read data")
+                    raise CommunicationReadTimeout("Unable to read {0} bytes, only {1} available".format(length, len(data)))
 
         return data
 
@@ -83,12 +63,11 @@ class DebugPort(CommunicationPort):
 
         return len(data)
 
-    def writeToOutputBuffer(self, data, endPointIndex):
+    def writeToOutputBuffer(self, data, endPointIndex=0):
         self.outputBuffers[endPointIndex].extend(data)
 
     def processInputBuffers(self, endPointIndex):
         # We default to ECHO for simplicity
-
         inputBytes = self.inputBuffers[endPointIndex]
 
         # Do something, here we do an Echo


### PR DESCRIPTION
## Summary

Recovers an unpushed commit (`e9e4faf`, authored 2026-03-01) that was sitting on a stale local `hamamatsu` branch. Cherry-picked onto a fresh branch off `master`, with the one conflict resolved (PR #74 fixed the `endPointIndex` unbound bug differently — kept that style since it's already on master).

## What this changes in `DebugPort`

- **`numberOfEndPoints=1` parameter** on `__init__` — `inputBuffers`/`outputBuffers` are now sized to the requested endpoint count rather than hard-coded to 2. Lets USB-style multi-endpoint devices use `DebugPort` directly.
- **Fixed `flush()`** — was writing to a nonexistent `self.buffers` attribute. Now properly resets each `inputBuffers[i]` and `outputBuffers[i]` to empty bytearrays.
- **`defaultTimeout = 500`** attribute added.
- **`readData` error message** — now reports `\"Unable to read N bytes, only M available\"` rather than a generic timeout, which is much more useful when debugging stuck reads.
- **`writeToOutputBuffer`** — `endPointIndex` parameter is now keyword-defaulted to `0` (was required positional).
- **Removed `DebugDataCommand`** — the broken skeleton class that referenced unassigned attributes (`self.data`, `self.replyDataLength`, `self.replyHexRegex`). One of the items flagged in the earlier code review.

## Relationship to PR #74

PR #74 (latent-bug fixes, merged) included a fix for `readData`/`writeData` leaving `endPointIndex` unbound when an explicit `endPoint` was passed. This commit had the same fix with slightly different ternary phrasing. The cherry-pick conflict was resolved in favor of PR #74's style (since it's already on master); behavior is identical.

## Test plan

- [ ] `python3 -m pytest hardwarelibrary/tests/testCommunicationPorts.py -v` — should report 84 passed, 29 skipped (hardware-gated). Already verified locally.
- [ ] Spot-check: instantiate `DebugPort(numberOfEndPoints=3)` and confirm `flush()` and `bytesAvailable(endPoint=2)` work.

## History note

The commit was authored on a local-only branch on 2026-03-01 and never pushed. Surfaced during a session refresh today and rescued before deletion. Original author: Daniel Côté (preserved via cherry-pick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)