### PR TITLE
Add pytest as a dev optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,12 @@ dependencies = [
   "LabJackPython"
 ]
 
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "pytest-cov",
+]
+
 [project.urls]
 Homepage = "https://github.com/DCC-Lab/PyHardwareLibrary"
 


### PR DESCRIPTION
## Summary

Declares \`pytest\` and \`pytest-cov\` as optional dev dependencies in \`pyproject.toml\`, so anyone setting up the project's \`.venv\` from a clean install ends up with a working test runner without ad-hoc \`pip install\`.

## What changed

\`\`\`toml
[project.optional-dependencies]
dev = [
  "pytest",
  "pytest-cov",
]
\`\`\`

## How to use

After cloning, the standard editable install with dev extras:

\`\`\`
pip install -e ".[dev]"
\`\`\`

…now produces a venv that can run the test suite directly:

\`\`\`
python -m pytest hardwarelibrary/tests/testCommunicationPorts.py -v
\`\`\`

## Motivation

The repo's \`.venv\` already had every runtime dependency the library uses (PyUSB, pylablib, LabJackPython, pyserial, pyftdi, PyVISA, etc.) plus \`hardwarelibrary\` itself in editable mode — but no test runner. Running tests required either falling back to a system Python that happened to have pytest, or installing pytest manually into the venv. Making it a declared dev extra removes that friction.

## Test plan

- [x] \`pip install -e ".[dev]"\` succeeds in a fresh venv install
- [x] \`python -m pytest hardwarelibrary/tests/testCommunicationPorts.py\` runs and reports 84 passed, 29 skipped — same result as the previous (system-python) runs
- [ ] Optional: confirm \`pytest-cov\` is wired (e.g. \`pytest --cov=hardwarelibrary\` produces coverage output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)