### PR TITLE
Match Sutter MP-285 13-byte position reply (no prefix echo)

### DIFF
--- a/hardwarelibrary/motion/sutterdevice.py
+++ b/hardwarelibrary/motion/sutterdevice.py
@@ -25,9 +25,9 @@ class SutterDevice(LinearMotionDevice):
                             replyDataLength=1, unpackingMask='<c'),
         "GET_POSITION": DataCommand(name="GET_POSITION", prefix=b'C',
                                     data=pack('<cc', b'C', b'\r'),
-                                    replyDataLength=14, unpackingMask='<xlllx',
-                                    responseFormat='<clllc',
-                                    responseFields=('header', 'x', 'y', 'z', 'terminator')),
+                                    replyDataLength=13, unpackingMask='<lllx',
+                                    responseFormat='<lllc',
+                                    responseFields=('x', 'y', 'z', 'terminator')),
         "HOME": DataCommand(name="HOME", prefix=b'H',
                             data=pack('<cc', b'H', b'\r'),
                             replyDataLength=1, unpackingMask='<c'),
@@ -172,8 +172,7 @@ class SutterDevice(LinearMotionDevice):
                 self.zSteps = params['z']
                 return b'\r'
             elif name == 'GET_POSITION':
-                return {'header': b'c', 'x': self.xSteps,
-                        'y': self.ySteps, 'z': self.zSteps,
+                return {'x': self.xSteps, 'y': self.ySteps, 'z': self.zSteps,
                         'terminator': b'\r'}
             elif name == 'HOME':
                 self.xSteps = self.ySteps = self.zSteps = 0

--- a/hardwarelibrary/tests/testSutterSerialPort.py
+++ b/hardwarelibrary/tests/testSutterSerialPort.py
@@ -56,8 +56,8 @@ class BaseTestCases:
 
             payload = bytearray('c',encoding='utf-8')
             self.port.writeData(payload)
-            data = self.port.readData(length=1 + 4*3 + 1)
-            (x,y,z) = unpack("<xlllx", data)
+            data = self.port.readData(length=4*3 + 1)
+            (x,y,z) = unpack("<lllx", data)
             self.assertTrue( x == 1)
             self.assertTrue( y == 2)
             self.assertTrue( z == 3)


### PR DESCRIPTION
## Summary

Updates the \`SutterDevice\` \`GET_POSITION\` command to expect a **13-byte reply** (\`<lllx>\`: 3 int32 positions + b'\r' terminator) instead of the previous 14-byte assumption (\`<xlllx>\`: prefix echo + 3 int32 + terminator).

Verified live against a Sutter ROE-200 (serial \`SIDCACD9\`) — the device replies with 13 bytes, no echoed command prefix.

## Background

The Sutter MP-285 protocol has two response modes for \`GET_POSITION\`:

- **Echo on:** 14-byte reply with the command character \`C\` echoed as the first byte
- **Echo off:** 13-byte reply with no prefix

The library previously assumed echo-on. Hardware testing in this session showed the same physical device returning 14 bytes early on, then 13 bytes after a power cycle — confirming the mode is not stable across firmware resets.

## Changes

- \`hardwarelibrary/motion/sutterdevice.py\`: \`GET_POSITION\` command
  - \`replyDataLength\`: 14 → 13
  - \`unpackingMask\`: \`<xlllx\` → \`<lllx\`
  - \`responseFormat\` (mock side): \`<clllc\` → \`<lllc\`
  - \`responseFields\` (mock side): drops \`'header'\`
  - \`DebugSerialPort.process_command\` for \`GET_POSITION\`: drops \`'header': b'c'\` from the returned dict
- \`hardwarelibrary/tests/testSutterSerialPort.py::testMoveGet\`:
  - \`readData\` length: 14 → 13
  - \`unpack\` format: \`<xlllx\` → \`<lllx\`

Total: 6 insertions, 7 deletions across 2 files.

## Caveat — this is a unilateral mode switch

If a future MP-285 boots into echo-on mode (the previous library assumption), \`GET_POSITION\` will fail with a 14-byte read that includes the echoed prefix as a corrupting offset.

**The robust long-term fix is one of:**
- Detect/toggle the echo mode at \`doInitializeDevice\` time (need to identify the right Sutter command — not currently documented in this repo)
- Make \`GET_POSITION\` tolerate both 13- and 14-byte replies (peek for \`\\r\` or try both formats)

This PR opts for the simpler one-mode fix because (a) the device is clearly in 13-byte mode for the current lab unit, and (b) implementing dual-mode handling is a more invasive change to the \`DataCommand\` machinery.

## Test plan

- [x] Mock-side \`TestSutterDebugSerialPort\` tests still pass (7/7) — dual-role mock kept in sync
- [x] Real-hardware \`TestSutterDevice\` tests pass against the live ROE-200 with stage actually moving (timing confirms: \`testDeviceMoveBy\` 1.33s, \`testDeviceMove\` 0.91s, \`testDeviceHome\` 0.89s)
- [x] \`testSutterSerialPort.py\` full suite: 14 passed, 10 skipped (pyserial-based tests skip because pyserial doesn't enumerate the Sutter on macOS via libusb — pre-existing environmental skip)
- [ ] Verify against an MP-285 in echo-on mode before this is trusted as a universal fix

## Related

Surfaced while bringing up live Sutter hardware to validate PR #73's table-driven debug port pattern. The dual-role consistency between the device reply parser and the mock's response builder caught the mock test failure when only the receive side was updated — exactly the safety net the pattern is supposed to provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)