### PR TITLE
Spectrometer.display() / .displayAny() auto-init the device

### DIFF
--- a/hardwarelibrary/spectrometers/base.py
+++ b/hardwarelibrary/spectrometers/base.py
@@ -15,7 +15,7 @@ import usb.util
 import usb.backend.libusb1
 
 from pathlib import *
-from hardwarelibrary.physicaldevice import PhysicalDevice
+from hardwarelibrary.physicaldevice import PhysicalDevice, DeviceState
 from hardwarelibrary.spectrometers.viewer import *
 
 class NoSpectrometerConnected(RuntimeError):
@@ -45,7 +45,14 @@ class Spectrometer(PhysicalDevice):
         raise NotImplementedError("Derived class must implement {0}".format(fctName))
 
     def display(self):
-        """ Display the spectrum with the SpectraViewer class."""
+        """Display the spectrum with the SpectraViewer class.
+
+        Initializes the device first if it isn't already in Ready
+        state, so that one-liners like Spectrometer.any().display()
+        work without the caller remembering initializeDevice().
+        """
+        if self.state != DeviceState.Ready:
+            self.initializeDevice()
         viewer = SpectraViewer(spectrometer=self)
         viewer.display()
 
@@ -161,7 +168,7 @@ class Spectrometer(PhysicalDevice):
     def displayAny(cls):
         spectrometer = cls.any()
         if spectrometer is not None:
-            SpectraViewer(spectrometer).display()
+            spectrometer.display()
 
     @classmethod
     def any(cls) -> 'Spectrometer':


### PR DESCRIPTION
## Summary

Makes the convenience one-liner work:

\`\`\`python
from hardwarelibrary.spectrometers import Spectrometer
Spectrometer.any().display()
\`\`\`

Previously this crashed mid-render with \`UnableToCommunicate: endpoint cannot be none\` because \`Spectrometer.any()\` returns an *Unconfigured* device but \`display()\` went straight to \`SpectraViewer.display()\`, which immediately called \`getSerialNumber()\` on the device — hitting a USB endpoint that wasn't set up yet.

## What changed

\`hardwarelibrary/spectrometers/base.py\`:

1. \`Spectrometer.display()\` now checks \`self.state\` and calls \`self.initializeDevice()\` if not already \`Ready\` before opening the viewer.
2. \`Spectrometer.displayAny()\` delegates to \`spectrometer.display()\` instead of constructing \`SpectraViewer\` directly — both entry points now share the auto-init path.
3. \`DeviceState\` added to the \`physicaldevice\` import (wasn't bound in this module before).

10 insertions, 3 deletions.

## Why \`display()\` and not \`any()\`?

There's a design choice here: should the auto-init live in \`Spectrometer.any()\` (so the returned device is always Ready) or in \`display()\` (so display is robust regardless of the caller's path)?

I chose \`display()\` because:

- \`any()\` returning an Unconfigured device is sometimes *useful* — callers may want to set integration time or configure endpoints before opening. Init-on-any() would prevent that.
- \`display()\` calling itself with an Unconfigured device is *always wrong* — the very next thing it does is talk to the device.
- Following the same logic, \`getSpectrum()\` and similar methods could also auto-init, but those are read-once-and-leave patterns and don't have the same "obvious one-liner that should just work" property.

## Test plan

- [x] \`Spectrometer.any().display()\` against a live Ocean Optics USB2000+: viewer opens, displays the live spectrum, closes cleanly.
- [x] Existing \`TestSpectrometerPhysicalDevice\` tests still pass (10 passed, 2 skipped on the DM-disabled tests from PR #82). No regressions.
- [ ] If a future contributor relies on \`Spectrometer.any()\` returning an Unconfigured device specifically, that contract is preserved by this PR.

## Related

This was flagged during the same live-hardware bringup session that produced PR #82 (Spectrometer.any() over DeviceManager) — both are about making the spectrometer API actually usable without the caller knowing too much about the framework's internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)