### PR TITLE
Unify sendCommand on PhysicalDevice (closes #80)

### DIFF
--- a/hardwarelibrary/communication/commands.py
+++ b/hardwarelibrary/communication/commands.py
@@ -254,10 +254,12 @@ class TextCommand(Command):
             return bytearray(formatted.encode('utf-8'))
         return super().formatResponse(result)
 
-    def send(self, port, params=None) -> bool:
+    def send(self, port, params=None, **kwargs) -> bool:
         try:
             if params is not None:
                 textCommand = self.requestEncoder.format(params)
+            elif kwargs:
+                textCommand = self.requestEncoder.format(**kwargs)
             else:
                 textCommand = self.requestEncoder
 
@@ -312,10 +314,12 @@ class MultilineTextCommand(Command):
     def payload(self):
         return self.requestEncoder
 
-    def send(self, port, params=None) -> bool:
+    def send(self, port, params=None, **kwargs) -> bool:
         try:
             if params is not None:
                 textCommand = self.requestEncoder.format(params)
+            elif kwargs:
+                textCommand = self.requestEncoder.format(**kwargs)
             else:
                 textCommand = self.requestEncoder
 
@@ -475,12 +479,14 @@ class DataCommand(Command):
             return replyBytes
         return struct.unpack(self.replyDecoder.format, replyBytes)
 
-    def send(self, port) -> bool:
+    def send(self, port, **params) -> bool:
         try:
-            port.writeData(data=self.data, endPoint=self.endPoints[0])
+            data = self.buildSendData(**params)
+            port.writeData(data=data, endPoint=self.endPoints[0])
             self.isSent = True
             if self.replyDecoder is not None and self.replyDecoder.length > 0:
                 self.reply = port.readData(length=self.replyDecoder.length)
+                self.matchGroups = self.unpackReply(self.reply)
             self.isSentSuccessfully = True
         except Exception as err:
             self.exceptions.append(err)

--- a/hardwarelibrary/communication/serialport.py
+++ b/hardwarelibrary/communication/serialport.py
@@ -26,7 +26,7 @@ class SerialPort(CommunicationPort):
        or the find_url.py script from the distribution. More info: https://eblot.github.io/pyftdi/api/usbtools.html
        You have to add any custom VID/PID when using tools (but they are added here in SerialPort) @line 30.
     """
-    def __init__(self, idVendor=None, idProduct=None, serialNumber=None, portPath=None, port=None):
+    def __init__(self, idVendor=None, idProduct=None, serialNumber=None, portPath=None, port=None, delay=0):
         CommunicationPort.__init__(self)
 
         try:
@@ -46,6 +46,7 @@ class SerialPort(CommunicationPort):
             port.close()
 
         self.port = None # direct port, must be closed.
+        self.delay = delay  # seconds to wait before each read/write (Sutter MP-285 needs ~0.1)
 
     @classmethod
     def matchSinglePort(cls, idVendor=None, idProduct=None, serialNumber=None):
@@ -195,6 +196,8 @@ class SerialPort(CommunicationPort):
 
     def readData(self, length, endPoint=0) -> bytearray:
         with self.portLock:
+            if self.delay > 0:
+                time.sleep(self.delay)
             data = self.port.read(length)
             if len(data) != length:
                 raise CommunicationReadTimeout("Only obtained {0}".format(data))
@@ -203,6 +206,8 @@ class SerialPort(CommunicationPort):
 
     def writeData(self, data, endPoint=0) -> int:
         with self.portLock:
+            if self.delay > 0:
+                time.sleep(self.delay)
             nBytesWritten = self.port.write(data)
             if nBytesWritten != len(data):
                 raise IOError("Not all bytes written to port")

--- a/hardwarelibrary/motion/sutterdevice.py
+++ b/hardwarelibrary/motion/sutterdevice.py
@@ -68,13 +68,15 @@ class SutterDevice(LinearMotionDevice):
                 if portPath is None:
                     raise PhysicalDevice.UnableToInitialize("No Sutter Device connected")
 
-                self.port = SerialPort(portPath=portPath)
+                self.port = SerialPort(portPath=portPath, delay=0.1)
                 self.port.open(baudRate=128000, timeout=10)
 
             if self.port is None:
                 raise PhysicalDevice.UnableToInitialize("Cannot allocate port for serial '{0}'".format(self.serialNumber))
 
-            self.positionInMicrosteps()
+            # Verify the device is talking. Direct .send() bypasses sendCommand's
+            # state check, which would reject because state is not yet Ready here.
+            self.commands["GET_POSITION"].send(port=self.port)
 
         except Exception as error:
             if self.port is not None:
@@ -86,60 +88,21 @@ class SutterDevice(LinearMotionDevice):
         self.port.close()
         self.port = None
 
-    def sendCommandBytes(self, commandBytes):
-        """ The function to write a command to the endpoint. It will initialize the device 
-        if it is not alread initialized. On failure, it will warn and shutdown."""
-        if self.port is None:
-            self.initializeDevice()
-        
-        time.sleep(0.1)
-        nBytesWritten = self.port.writeData(commandBytes)
-        if nBytesWritten != len(commandBytes):
-            raise Exception(f"Unable to send command {commandBytes} to device.")
-
-    def readReply(self, size, format) -> tuple:
-        """ The function to read a reply from the endpoint. It will initialize the device
-        if it is not already initialized. On failure, it will warn and shutdown.
-        It will unpack the reply into a tuple.
-        """
-        if format is None:
-            raise Exception("You must provide a format for unpacking in readReply")
-
-        if self.port is None:
-            self.initializeDevice()
-
-        time.sleep(0.1)
-        replyBytes = self.port.readData(size)
-        if len(replyBytes) != size:
-            raise Exception(f"Not enough bytes read in readReply {replyBytes}")
-
-        # print(replyBytes, format)
-        # print(unpack(format, replyBytes))
-        return unpack(format, replyBytes)
-
-    def sendCommand(self, name, **params):
-        """Send a command from the commands dict and return the unpacked reply."""
-        cmd = self.commands[name]
-        data = cmd.buildSendData(**params)
-        self.sendCommandBytes(data)
-        if cmd.replyDecoder is not None and cmd.replyDecoder.length > 0:
-            return self.readReply(cmd.replyDecoder.length, cmd.replyDecoder.format)
-        return None
-
     def positionInMicrosteps(self) -> (int, int, int):  # for compatibility
         return self.doGetPosition()
 
     def doGetPosition(self) -> (int, int, int):
         """ Returns the position in microsteps """
-        (x, y, z) = self.sendCommand("GET_POSITION")
+        cmd = self.sendCommand("GET_POSITION")
+        (x, y, z) = cmd.matchGroups
         return (x, y, z)
 
     def doMoveTo(self, position):
         """ Move to a position in microsteps """
         x, y, z = position
-        reply = self.sendCommand("MOVE", x=int(x), y=int(y), z=int(z))
-        if reply != (b'\r',):
-            raise Exception(f"Expected carriage return, but got '{reply}' instead.")
+        cmd = self.sendCommand("MOVE", x=int(x), y=int(y), z=int(z))
+        if cmd.matchGroups != (b'\r',):
+            raise Exception(f"Expected carriage return, but got '{cmd.matchGroups}' instead.")
 
     def doMoveBy(self, displacement):
         dx, dy, dz = displacement
@@ -150,15 +113,15 @@ class SutterDevice(LinearMotionDevice):
             raise Exception("Unable to read position from device")
 
     def doHome(self):
-        reply = self.sendCommand("HOME")
-        if reply != (b'\r',):
-            raise Exception(f"Expected carriage return, but got {reply} instead.")
+        cmd = self.sendCommand("HOME")
+        if cmd.matchGroups != (b'\r',):
+            raise Exception(f"Expected carriage return, but got {cmd.matchGroups} instead.")
 
     def work(self):
         self.home()
-        reply = self.sendCommand("WORK")
-        if reply != (b'\r',):
-            raise Exception(f"Expected carriage return, but got {reply} instead.")
+        cmd = self.sendCommand("WORK")
+        if cmd.matchGroups != (b'\r',):
+            raise Exception(f"Expected carriage return, but got {cmd.matchGroups} instead.")
 
 
     class DebugSerialPort(TableDrivenDebugPort):

--- a/hardwarelibrary/physicaldevice.py
+++ b/hardwarelibrary/physicaldevice.py
@@ -181,11 +181,21 @@ class PhysicalDevice(ABC):
         else:
             raise RuntimeError("No status loop running")
 
-    def sendCommand(self, command):
+    def sendCommand(self, name, **params):
+        """Look up the named command in self.commands, send it through
+        self.port, and return the Command object so callers can read
+        .reply / .matchGroups / .exceptions / .isSentSuccessfully.
+
+        Params are passed through to Command.send: TextCommand uses them
+        for .format(**params) substitution into text_format; DataCommand
+        uses them for buildSendData(**params) when sendFormat is set.
+        """
         if self.state != DeviceState.Ready:
             raise PhysicalDevice.NotInitialized
 
-        command.send(port=self.port)
+        command = self.commands[name]
+        command.send(port=self.port, **params)
+        return command
 
     @classmethod
     def any(cls):

--- a/hardwarelibrary/tests/testConnectSutter.py
+++ b/hardwarelibrary/tests/testConnectSutter.py
@@ -9,7 +9,7 @@ class TestConnectSutter(unittest.TestCase):
     def testConnectDebugSutter(self):
         sutter = SutterDevice(serialNumber="debug")
         # The port is not open until initializeDevice()
-        sutter.doInitializeDevice()
+        sutter.initializeDevice()
         
         position = sutter.position()
 
@@ -19,7 +19,7 @@ class TestConnectSutter(unittest.TestCase):
 
     def testMoveToWithDebugSutter(self):
         sutter = SutterDevice("debug")
-        sutter.doInitializeDevice()
+        sutter.initializeDevice()
 
         sutter.moveTo((0, 100, 4000))
         position = sutter.position()

--- a/hardwarelibrary/tests/testPhysicalDevice.py
+++ b/hardwarelibrary/tests/testPhysicalDevice.py
@@ -263,9 +263,9 @@ class TestEchoPhysicalDevice(BaseTestCases.TestPhysicalDeviceBase):
         self.device.initializeDevice()
         for name, command in self.device.commands.items():
             try:
-                self.device.sendCommand(command)
+                self.device.sendCommand(name)
             except Exception as err:
-                self.fail("Unable to send command {0} to device {1}: {2}".format(command.name, self.device, err))
+                self.fail("Unable to send command {0} to device {1}: {2}".format(name, self.device, err))
         self.device.shutdownDevice()
 
 class TestDebugEchoPhysicalDevice(BaseTestCases.TestPhysicalDeviceBase):
@@ -277,9 +277,9 @@ class TestDebugEchoPhysicalDevice(BaseTestCases.TestPhysicalDeviceBase):
         self.device.initializeDevice()
         for name, command in self.device.commands.items():
             try:
-                self.device.sendCommand(command)
+                self.device.sendCommand(name)
             except Exception as err:
-                self.fail("Unable to send command {0} to device {1}: {2}".format(command.name, self.device, err))
+                self.fail("Unable to send command {0} to device {1}: {2}".format(name, self.device, err))
         self.device.shutdownDevice()
 
 


### PR DESCRIPTION
Closes #80.

## Summary

Before this PR, two methods called \`sendCommand\` existed in the codebase with completely different contracts:

- \`PhysicalDevice.sendCommand(command)\` — takes a \`Command\` object, sends it via \`command.send(port=self.port)\`, returns \`None\`.
- \`SutterDevice.sendCommand(name, **params)\` — looks up the named command, packs bytes via \`DataCommand.buildSendData(**params)\`, returns the unpacked reply tuple.

The Sutter version shadowed the base via Python's MRO. Same method name, fundamentally different APIs. Every new device adopting the dual-role commands pattern that PR #73 introduced would have needed a parallel override to get the \`(name, **params)\` ergonomics.

This PR collapses them into a single unified \`PhysicalDevice.sendCommand(name, **params)\` and deletes the \`SutterDevice\` override along with its helper methods.

## What changed

| File | Change |
|---|---|
| \`communication/commands.py\` | \`DataCommand.send\` accepts \`**params\`, uses \`buildSendData(**params)\` when \`sendFormat\` is set, populates \`self.matchGroups\` from \`unpackReply(self.reply)\`. \`TextCommand.send\` / \`MultilineTextCommand.send\` add a \`**kwargs\` argument alongside the existing \`params=\` (backward compatible) so callers can use named-placeholder \`text_format\`s like \`'g r{register}\\\\n'\`. |
| \`physicaldevice.py\` | \`sendCommand(command)\` becomes \`sendCommand(name, **params)\`. Looks up the command in \`self.commands\`, calls \`cmd.send(port=self.port, **params)\`, returns the \`Command\` so callers have access to \`.reply\` / \`.matchGroups\` / \`.exceptions\` / \`.isSentSuccessfully\`. |
| \`communication/serialport.py\` | \`SerialPort(..., delay=0)\` parameter added. When set, \`time.sleep(delay)\` runs before each \`writeData\` and \`readData\`. Moves Sutter's MP-285 timing margin out of the device class and into the port where it belongs. |
| \`motion/sutterdevice.py\` | Deletes the local \`sendCommand\` override and the \`sendCommandBytes\` / \`readReply\` helpers (~30 lines). Opens its \`SerialPort\` with \`delay=0.1\`. Updates \`doGetPosition\` / \`doMoveTo\` / \`doHome\` / \`work\` to read \`cmd.matchGroups\` from the returned \`Command\`. \`doInitializeDevice\` uses \`commands["GET_POSITION"].send(port=self.port)\` directly to probe the hardware (since \`sendCommand\`'s \`state==Ready\` guard hasn't been satisfied at that point yet). |
| \`tests/testPhysicalDevice.py\` | \`testEchoCommands\` passes the command name string, not the command object. |
| \`tests/testConnectSutter.py\` | Switches from \`sutter.doInitializeDevice()\` (internal) to \`sutter.initializeDevice()\` (public lifecycle that sets state to Ready). The internal-method shortcut was a pre-existing test bug that only surfaced because the state guard now applies to more code paths. |

Net: **+50 / −67 lines** across 6 files.

## Test plan

- [x] Full suite: **261 passed, 203 skipped, 0 failures**. Skips are hardware-gated tests (no hardware attached at the moment).
- [x] \`testCommandRecognition.py\` (38 unit tests on the Command machinery): all pass with no changes — the new \`send\` signatures are backward compatible with positional \`params=\` callers.
- [x] \`testSutterDevice.py\` (falls back to \`SutterDevice("debug")\` when no Sutter): 7/7 pass.
- [x] \`testTableDrivenDebugPort.py\` (12 minimal fixture-based tests): 12/12 pass.
- [ ] Verify against a live Sutter MP-285. Last time it was on the bus this session, the 13-byte-position fix (#81) was needed; the \`delay=0.1\` substitute for the old \`time.sleep(0.1)\` calls inside \`sendCommandBytes\`/\`readReply\` should be functionally identical.

## Why move timing into the port?

The Sutter MP-285's serial protocol needs ~100 ms between commands or the device gets out of sync. The old code put \`time.sleep(0.1)\` inside Sutter-specific helpers (\`sendCommandBytes\`, \`readReply\`), then called those from the Sutter-specific \`sendCommand\`. After unifying \`sendCommand\`, those helpers had nowhere to live except the port. The port is also the correct architectural home: timing margin is a property of the wire, not the device's command vocabulary.

## Migration impact

This is a **breaking change** to \`PhysicalDevice.sendCommand\`'s signature. The two callers in this repo (\`testEchoCommands\` in \`testPhysicalDevice.py\`, plus \`SutterDevice\`'s own \`do*\` methods) are migrated in this PR. Other devices that don't currently use \`PhysicalDevice.sendCommand\` (\`IntegraDevice\` calls \`cmd.send(port=self.port)\` directly; \`OISpectrometer\` has its own \`sendCommand\`) are not affected.

Downstream code that relied on \`PhysicalDevice.sendCommand(command)\` will need to switch to \`sendCommand(name)\` where \`name\` is the key in \`device.commands\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)