### PR TITLE
Make device contracts explicit with abstract base classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This file is for AI-assisted contributors. Humans should read `README.md` and th
 
 Core triad — all under `hardwarelibrary/`:
 
-- `physicaldevice.py:PhysicalDevice` — base for every device. Owns lifecycle (`initializeDevice` / `shutdownDevice`), state machine (`DeviceState`), port handle, and monitoring thread.
+- `physicaldevice.py:PhysicalDevice` — abstract base (`abc.ABC`) for every device. Owns lifecycle (`initializeDevice` / `shutdownDevice`), state machine (`DeviceState`), port handle, and monitoring thread. The lifecycle hooks `doInitializeDevice` / `doShutdownDevice` are `@abstractmethod`, so a driver that omits either fails at instantiation rather than at call time.
 - `devicemanager.py:DeviceManager` — singleton. Discovers connected USB devices, dispatches add/remove notifications.
 - `notificationcenter.py:NotificationCenter` — Cocoa-style pub/sub. Devices post notifications on state changes and measurements.
 
@@ -36,27 +36,29 @@ Communication abstractions under `hardwarelibrary/communication/`:
 
 ## Device families
 
-Each family has a protocol base class. Implement these methods when adding a device:
+Each family has an **abstract base class**. A driver subclasses it and implements the `@abstractmethod` hooks below; forgetting one raises `TypeError` at instantiation, naming the missing method. These are the family hooks, on top of `doInitializeDevice` / `doShutdownDevice` inherited from `PhysicalDevice`.
 
-| Family | Folder | Base class | Required `do*` methods |
+| Family | Folder | Abstract base class | Required hooks to implement |
 |---|---|---|---|
 | Linear motion | `motion/` | `LinearMotionDevice` | `doMoveTo`, `doMoveBy`, `doGetPosition`, `doHome` |
 | Rotation | `motion/` | `RotationDevice` | `doMoveTo`, `doMoveBy`, `doGetOrientation`, `doHome` |
 | Power meter | `powermeters/` | `PowerMeterDevice` | `doGetAbsolutePower`, `doGetCalibrationWavelength`, `doSetCalibrationWavelength` |
-| Spectrometer | `spectrometers/` | `Spectrometer` (`base.py`) | `getSpectrum`, `setIntegrationTime`, `getIntegrationTime` |
-| Oscilloscope | `oscilloscope/` | `OscilloscopeDevice` | per-instrument SCPI methods |
+| Spectrometer | `spectrometers/` | `Spectrometer` (`base.py`) | `getSpectrum`, `getSerialNumber` (here the public method *is* the hook; no `doXxx` wrapper) |
+| Oscilloscope | `oscilloscope/` | `OscilloscopeDevice` | instantiated directly (Tektronix), no family/driver split; per-instrument SCPI methods |
 | Camera | `cameras/` | `CameraDevice` | `doCaptureFrame` |
-| Laser source | `sources/` | `LaserSourceDevice` | `doTurnOn`, `doTurnOff`, `doSetPower`, `doGetPower` |
-| DAQ | `daq/` | `AnalogIOProtocol` / `DigitalIOProtocol` (mixins) | `getAnalogVoltage`, `setAnalogVoltage`, `getDigitalValue`, `setDigitalValue` |
+| Laser source | `sources/` | `LaserSourceDevice` | `doTurnOn`, `doTurnOff`, `doSetPower`, `doGetPower`, `doGetOnOffState`, `doGetInterlockState` |
+| DAQ | `daq/` | capability mixins (see below) | one method per mixin: `getAnalogVoltage` / `setAnalogVoltage` / `getDigitalValue` / `setDigitalValue` |
+
+DAQ uses **interface-segregated capability mixins** instead of one base class, because a device may do any subset of read/write on analog/digital lines: `AnalogInputDevice` (`getAnalogVoltage`), `AnalogOutputDevice` (`setAnalogVoltage`), `DigitalInputDevice` (`getDigitalValue`), `DigitalOutputDevice` (`setDigitalValue`), plus `AnalogIODevice` / `DigitalIODevice` that combine each pair. The `configure*` and `direction*` methods are optional no-op hooks. A driver combines `PhysicalDevice` with the mixins it needs, e.g. `class LabjackDevice(PhysicalDevice, AnalogIODevice, DigitalIODevice)`.
 
 ## Adding a new device
 
 Reference implementation: `hardwarelibrary/daq/labjackdevice.py`. The pattern:
 
-1. Subclass the family base **and** `PhysicalDevice`.
+1. Subclass the family base (it already extends `PhysicalDevice`). For DAQ, combine `PhysicalDevice` with the capability mixins you need, e.g. `class FooDAQ(PhysicalDevice, AnalogIODevice)`.
 2. Set class attributes `classIdVendor` and `classIdProduct` (USB VID/PID, or the equivalent for serial-only devices).
 3. Implement `doInitializeDevice` and `doShutdownDevice`. Keep them minimal — open the port, close the port.
-4. Implement the family-required `do*` methods.
+4. Implement the family's abstract hooks (see the table). Omitting one raises `TypeError` at instantiation, so the class will not even construct until the contract is complete.
 5. Add a companion `DebugXxxDevice(XxxDevice)` in the same file. Stub the hardware, store state in dicts. Use `classIdVendor = 0xFFFF` and a unique `classIdProduct >= 0xFFF0`.
 6. Export both from the family's `__init__.py`.
 7. Add a test file `hardwarelibrary/tests/testXxx.py`. Include a `TestDebugXxxDevice` class (always runs) and a `TestXxxDevice` class that skips when hardware is absent.
@@ -68,6 +70,7 @@ Reference implementation: `hardwarelibrary/daq/labjackdevice.py`. The pattern:
 - **The `commands` dict on `PhysicalDevice` is half-finished.** Only `IntegraDevice` (`powermeters/integradevice.py`) and `EchoDevice` use it. For new devices, do not adopt this pattern — implement protocol bytes directly in your `do*` methods, the way `SutterDevice`, `CoboltDevice`, and `OISpectrometer` do. The `send-side-migration` branch was meant to complete the pattern; until it merges, treat it as experimental.
 - **`spectrometers/oceaninsight.py`** is 967 lines and has known structural problems (duplicate exception classes, a `DebugSpectro` that doesn't inherit from `Spectrometer`, a duplicate `validateUSBBackend` whose macOS check is wrong). Do not copy from it. New spectrometers should subclass `spectrometers/base.py:Spectrometer` directly.
 - **`from X import *` in new files.** Many existing modules do this; resist mirroring. It hides what's in scope and confuses static tooling.
+- **No consumer-facing `typing.Protocol`s.** A prototype mirrored each family's public API as a `Protocol`, then it was dropped: the abstract base class is the type to use in hints (`def scan(stage: LinearMotionDevice)`), which keeps a single source of truth and avoids Protocol/class drift. The DAQ's former `AnalogIOProtocol` / `DigitalIOProtocol` are gone — use the ABC capability mixins.
 
 ## Branch hygiene
 

--- a/README-4-New-device-coding-example.md
+++ b/README-4-New-device-coding-example.md
@@ -215,6 +215,59 @@ if __name__ == '__main__':
 
 ```
 
+## Wiring it into PyHardwareLibrary: the device contract
+
+The script above proves the communication works. The library wraps that into a class, so the rest of the code never touches USB directly. Each family has an **abstract base class** that declares, as `@abstractmethod`, the few hooks a driver must provide; the public API (with notifications, unit handling, etc.) is already implemented on the base.
+
+A power meter subclasses `PowerMeterDevice`. The hooks to implement are:
+
+- `doInitializeDevice` / `doShutdownDevice` (inherited from `PhysicalDevice`) — open and close the port.
+- `doGetAbsolutePower`, `doGetCalibrationWavelength`, `doSetCalibrationWavelength` (from `PowerMeterDevice`).
+
+A minimal skeleton:
+
+```python
+from hardwarelibrary.powermeters import PowerMeterDevice
+from hardwarelibrary.communication import USBPort
+
+
+class IntegraDevice(PowerMeterDevice):
+    classIdVendor = 0x1ad5
+    classIdProduct = 0x0300
+
+    def __init__(self, serialNumber=None):
+        super().__init__(serialNumber, idProduct=self.classIdProduct, idVendor=self.classIdVendor)
+        self.port = None
+
+    def doInitializeDevice(self):
+        self.port = USBPort(idVendor=self.classIdVendor, idProduct=self.classIdProduct,
+                            interfaceNumber=0, defaultEndPoints=(1, 2))
+
+    def doShutdownDevice(self):
+        self.port.close()
+        self.port = None
+
+    def doGetAbsolutePower(self):
+        ...   # send "*CVU\r", parse the reply into self.absolutePower
+
+    def doGetCalibrationWavelength(self):
+        ...
+
+    def doSetCalibrationWavelength(self, wavelength):
+        ...
+```
+
+You never call `doGetAbsolutePower` yourself; callers use the public `measureAbsolutePower()`, which the base implements (it calls the hook and posts a `PowerMeterNotification.didMeasure`).
+
+Because the base class is abstract, the contract is enforced. Forget a hook and Python refuses to build the object:
+
+```
+TypeError: Can't instantiate abstract class IntegraDevice
+  without an implementation for abstract method 'doSetCalibrationWavelength'
+```
+
+so a half-written driver fails immediately and loudly, instead of later when a caller happens to hit the missing method.
+
 
 
 

--- a/hardwarelibrary/cameras/camera.py
+++ b/hardwarelibrary/cameras/camera.py
@@ -1,4 +1,5 @@
 import time
+from abc import abstractmethod
 from enum import Enum
 from hardwarelibrary.physicaldevice import PhysicalDevice
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification
@@ -33,6 +34,11 @@ class CameraDevice(PhysicalDevice):
         with self.lock:
             if self.isCapturing:
                 self.stop()
+
+    # Hardware hook a driver must implement to return one frame.
+    @abstractmethod
+    def doCaptureFrame(self):
+        ...
 
     def livePreview(self):
         NotificationCenter().postNotification(notificationName=CameraDeviceNotification.willStartCapture,

--- a/hardwarelibrary/daq/__init__.py
+++ b/hardwarelibrary/daq/__init__.py
@@ -1,4 +1,7 @@
 #__all__ = ["sutterdevice"]
 
-from .daqdevice import AnalogIOProtocol, DigitalIOProtocol
+from .daqdevice import (
+    AnalogInputDevice, AnalogOutputDevice, AnalogIODevice,
+    DigitalInputDevice, DigitalOutputDevice, DigitalIODevice,
+)
 from .labjackdevice import LabjackDevice, DebugLabjackDevice

--- a/hardwarelibrary/daq/daqdevice.py
+++ b/hardwarelibrary/daq/daqdevice.py
@@ -1,12 +1,35 @@
+from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Union, Optional, Protocol
+
 
 class DAQNotification(Enum):
     willAcquire    = "willAcquire"
     didAcquire     = "didAcquire"
 
-class AnalogIOProtocol(Protocol):
-    def configureAnalogIO(self, parameters:dict):
+
+class AnalogInputDevice(ABC):
+    """Analog input capability (ADC). Combine with PhysicalDevice in a driver."""
+
+    @abstractmethod
+    def getAnalogVoltage(self, channel):
+        ...
+
+
+class AnalogOutputDevice(ABC):
+    """Analog output capability (DAC). Combine with PhysicalDevice in a driver."""
+
+    @abstractmethod
+    def setAnalogVoltage(self, value, channel):
+        ...
+
+
+class AnalogIODevice(AnalogInputDevice, AnalogOutputDevice):
+    """Both analog input and output.
+
+    The configure and direction hooks are optional and default to no-ops.
+    """
+
+    def configureAnalogIO(self, parameters: dict):
         pass
 
     def getAnalogDirection(self, channel):
@@ -15,44 +38,34 @@ class AnalogIOProtocol(Protocol):
     def setAnalogDirection(self, channel):
         pass
 
-    def getAnalogVoltage(self, channel):
-        pass
 
-    def setAnalogVoltage(self, value, channel):
-        pass
+class DigitalInputDevice(ABC):
+    """Digital input capability. Combine with PhysicalDevice in a driver."""
 
-class DigitalIOProtocol(Protocol):
-    def configureDigitalIO(self, parameters:dict):
+    @abstractmethod
+    def getDigitalValue(self, channel):
+        ...
+
+
+class DigitalOutputDevice(ABC):
+    """Digital output capability. Combine with PhysicalDevice in a driver."""
+
+    @abstractmethod
+    def setDigitalValue(self, value, channel):
+        ...
+
+
+class DigitalIODevice(DigitalInputDevice, DigitalOutputDevice):
+    """Both digital input and output.
+
+    The configure and direction hooks are optional and default to no-ops.
+    """
+
+    def configureDigitalIO(self, parameters: dict):
         pass
 
     def getDigitalDirection(self, channel):
         pass
 
     def setDigitalDirection(self, channel):
-        pass
-
-    def getDigitalValue(self, channel):
-        pass
-
-    def setDigitalValue(self, value, channel):
-        pass
-
-class CounterProtocol(Protocol):
-    def configureCounters(self, parameters:dict):
-        pass
-
-    def getCounterValue(self, channel):
-        pass
-
-class TimerProtocol(Protocol):
-    def configureTimers(self, parameters:dict):
-        pass
-
-    def getTimerValue(self, channel):
-        pass
-
-    def startTimer(self, channel):
-        pass
-
-    def stopTimer(self, channel):
         pass

--- a/hardwarelibrary/daq/labjackdevice.py
+++ b/hardwarelibrary/daq/labjackdevice.py
@@ -1,9 +1,9 @@
 from hardwarelibrary.physicaldevice import PhysicalDevice, DeviceState, PhysicalDeviceNotification
-from hardwarelibrary.daq import AnalogIOProtocol, DigitalIOProtocol
+from hardwarelibrary.daq import AnalogIODevice, DigitalIODevice
 import u3
 
 
-class LabjackDevice(PhysicalDevice, AnalogIOProtocol, DigitalIOProtocol):
+class LabjackDevice(PhysicalDevice, AnalogIODevice, DigitalIODevice):
     """LabJack U3 (LV and HV). Use self.dev for features beyond the wrapped methods."""
 
     classIdVendor = 0x0cd5

--- a/hardwarelibrary/motion/linearmotiondevice.py
+++ b/hardwarelibrary/motion/linearmotiondevice.py
@@ -1,4 +1,6 @@
+from abc import abstractmethod
 from enum import Enum
+
 from hardwarelibrary.physicaldevice import *
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification
 
@@ -27,6 +29,24 @@ class LinearMotionDevice(PhysicalDevice):
         self.xMaxLimit = None
         self.yMaxLimit = None
         self.zMaxLimit = None
+
+    # Hardware hooks a driver must implement, on top of doInitializeDevice
+    # and doShutdownDevice inherited from PhysicalDevice.
+    @abstractmethod
+    def doMoveTo(self, position):
+        ...
+
+    @abstractmethod
+    def doMoveBy(self, displacement):
+        ...
+
+    @abstractmethod
+    def doGetPosition(self) -> tuple:
+        ...
+
+    @abstractmethod
+    def doHome(self):
+        ...
 
     def moveTo(self, position):
         NotificationCenter().postNotification(

--- a/hardwarelibrary/motion/rotationdevice.py
+++ b/hardwarelibrary/motion/rotationdevice.py
@@ -42,9 +42,7 @@ class DebugRotationDevice(RotationDevice):
     classIdProduct = 0xfffd
     classIdVendor = debugClassIdVendor
     def __init__(self):
-        super().__init__("debug", DebugLinearMotionDevice.classIdProduct, DebugLinearMotionDevice.classIdVendor )
-        self.orientation = None
-
+        super().__init__("debug", DebugRotationDevice.classIdProduct, DebugRotationDevice.classIdVendor)
         self._debugOrientation = 0
 
     def doGetOrientation(self) -> float:

--- a/hardwarelibrary/motion/rotationdevice.py
+++ b/hardwarelibrary/motion/rotationdevice.py
@@ -1,4 +1,6 @@
+from abc import abstractmethod
 from enum import Enum
+
 from hardwarelibrary.physicaldevice import *
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification
 
@@ -16,6 +18,24 @@ class RotationDevice(PhysicalDevice):
     def __init__(self, serialNumber:str, idProduct:int, idVendor:int):
         super().__init__(serialNumber, idProduct, idVendor)
         self.theta = None
+
+    # Hardware hooks a driver must implement, on top of doInitializeDevice
+    # and doShutdownDevice inherited from PhysicalDevice.
+    @abstractmethod
+    def doMoveTo(self, angle):
+        ...
+
+    @abstractmethod
+    def doMoveBy(self, deltaTheta):
+        ...
+
+    @abstractmethod
+    def doGetOrientation(self) -> float:
+        ...
+
+    @abstractmethod
+    def doHome(self):
+        ...
 
     def moveTo(self, angle):
         NotificationCenter().postNotification(RotationMotionNotification.willMove, notifyingObject=self, userInfo=angle)

--- a/hardwarelibrary/physicaldevice.py
+++ b/hardwarelibrary/physicaldevice.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from enum import Enum, IntEnum
 from threading import Thread, RLock
 
@@ -23,7 +24,7 @@ class PhysicalDeviceNotification(Enum):
     didShutdownDevice          = "didShutdownDevice"
     status                     = "status"
 
-class PhysicalDevice:
+class PhysicalDevice(ABC):
     class UnableToInitialize(Exception):
         pass
     class UnableToShutdown(Exception):
@@ -112,8 +113,9 @@ class PhysicalDevice:
                 NotificationCenter().postNotification(PhysicalDeviceNotification.didInitializeDevice, notifyingObject=self, userInfo=error)
                 raise PhysicalDevice.UnableToInitialize(error)
 
+    @abstractmethod
     def doInitializeDevice(self):
-        raise NotImplementedError("Base class must override doInitializeDevice()")
+        ...
 
     def initializeIfNeeded(self):
         if self.state == DeviceState.Unconfigured:
@@ -137,8 +139,9 @@ class PhysicalDevice:
                     self.port.close()
                     self.port = None
 
+    @abstractmethod
     def doShutdownDevice(self):
-        raise NotImplementedError("Base class must override doShutdownDevice()")
+        ...
 
     def startBackgroundStatusUpdates(self):
         with self.lock:

--- a/hardwarelibrary/powermeters/powermeterdevice.py
+++ b/hardwarelibrary/powermeters/powermeterdevice.py
@@ -1,5 +1,7 @@
 import time
+from abc import abstractmethod
 from enum import Enum
+
 from hardwarelibrary.communication import USBPort, TextCommand
 from hardwarelibrary.physicaldevice import *
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification
@@ -13,6 +15,20 @@ class PowerMeterDevice(PhysicalDevice):
         super().__init__(serialNumber, idProduct, idVendor)
         self.absolutePower = 0
         self.calibrationWavelength = None
+
+    # Hardware hooks a driver must implement, on top of doInitializeDevice
+    # and doShutdownDevice inherited from PhysicalDevice.
+    @abstractmethod
+    def doGetAbsolutePower(self):
+        ...
+
+    @abstractmethod
+    def doGetCalibrationWavelength(self):
+        ...
+
+    @abstractmethod
+    def doSetCalibrationWavelength(self, wavelength):
+        ...
 
     def measureAbsolutePower(self):
         self.doGetAbsolutePower()

--- a/hardwarelibrary/sources/cobolt.py
+++ b/hardwarelibrary/sources/cobolt.py
@@ -13,7 +13,7 @@ globalLock = RLock()
 class CoboltCantTurnOnWithAutostartOn(Exception):
     pass
 
-class CoboltDevice(PhysicalDevice, LaserSourceDevice):
+class CoboltDevice(LaserSourceDevice):
     commands = {
         "GET_POWER": TextCommand(
             name="GET_POWER",
@@ -95,8 +95,7 @@ class CoboltDevice(PhysicalDevice, LaserSourceDevice):
         else:
             self.portPath = None
 
-        PhysicalDevice.__init__(self, serialNumber, idVendor, idProduct)
-        LaserSourceDevice.__init__(self)
+        super().__init__(serialNumber=serialNumber, idProduct=idProduct, idVendor=idVendor)
         self.port = None
 
     def __del__(self):

--- a/hardwarelibrary/sources/lasersourcedevice.py
+++ b/hardwarelibrary/sources/lasersourcedevice.py
@@ -1,6 +1,9 @@
+from abc import abstractmethod
 
-class LaserSourceDevice:
+from hardwarelibrary.physicaldevice import PhysicalDevice
 
+
+class LaserSourceDevice(PhysicalDevice):
     def isLaserOn(self):
         return self.doGetOnOffState()
 
@@ -10,7 +13,7 @@ class LaserSourceDevice:
     def turnOff(self):
         self.doTurnOff()
 
-    def setPower(self, power:float):
+    def setPower(self, power: float):
         self.doSetPower(power)
 
     def power(self) -> float:
@@ -18,3 +21,29 @@ class LaserSourceDevice:
 
     def interlock(self) -> bool:
         return self.doGetInterlockState()
+
+    # Hardware hooks a driver must implement, on top of doInitializeDevice
+    # and doShutdownDevice inherited from PhysicalDevice.
+    @abstractmethod
+    def doTurnOn(self):
+        ...
+
+    @abstractmethod
+    def doTurnOff(self):
+        ...
+
+    @abstractmethod
+    def doSetPower(self, power: float):
+        ...
+
+    @abstractmethod
+    def doGetPower(self) -> float:
+        ...
+
+    @abstractmethod
+    def doGetOnOffState(self) -> bool:
+        ...
+
+    @abstractmethod
+    def doGetInterlockState(self) -> bool:
+        ...

--- a/hardwarelibrary/spectrometers/base.py
+++ b/hardwarelibrary/spectrometers/base.py
@@ -1,5 +1,6 @@
 import time
 import numpy as np
+from abc import abstractmethod
 from struct import *
 import csv
 from typing import NamedTuple
@@ -36,13 +37,16 @@ class Spectrometer(PhysicalDevice):
         self.wavelength = np.linspace(400,1000,1024)
         self.integrationTime = 10
 
+    # The contract a driver must implement. For spectrometers the public
+    # method is the hook itself (no doXxx wrapper), on top of
+    # doInitializeDevice and doShutdownDevice inherited from PhysicalDevice.
+    @abstractmethod
     def getSerialNumber(self):
-        fctName = inspect.currentframe().f_code.co_name
-        raise NotImplementedError("Derived class must implement {0}".format(fctName))
+        ...
 
+    @abstractmethod
     def getSpectrum(self) -> np.array:
-        fctName = inspect.currentframe().f_code.co_name
-        raise NotImplementedError("Derived class must implement {0}".format(fctName))
+        ...
 
     def display(self):
         """Display the spectrum with the SpectraViewer class.

--- a/hardwarelibrary/tests/testCobolt.py
+++ b/hardwarelibrary/tests/testCobolt.py
@@ -1,0 +1,69 @@
+import env
+import unittest
+import time
+
+from hardwarelibrary.physicaldevice import DeviceState
+from hardwarelibrary.sources.cobolt import CoboltDevice, CoboltCantTurnOnWithAutostartOn
+
+
+class TestDebugCoboltDevice(unittest.TestCase):
+    def setUp(self):
+        self.device = CoboltDevice(portPath="debug")
+        self.device.initializeDevice()
+
+    def tearDown(self):
+        if self.device.state == DeviceState.Ready:
+            self.device.shutdownDevice()
+
+    def testInitializedToReady(self):
+        self.assertEqual(self.device.state, DeviceState.Ready)
+
+    def testGetPower(self):
+        self.assertIsNotNone(self.device.power())
+
+    def testInterlockClosed(self):
+        self.assertTrue(self.device.interlock())
+
+    def testBootsWithAutostartOn(self):
+        self.assertTrue(self.device.autostartIsOn())
+
+    def testTurnOnRefusedWhileAutostartOn(self):
+        with self.assertRaises(CoboltCantTurnOnWithAutostartOn):
+            self.device.turnOn()
+
+    def testTurnOnAndOffWithAutostartOff(self):
+        self.device.turnAutostartOff()
+        self.device.turnOn()
+        self.assertTrue(self.device.isLaserOn())
+        self.device.turnOff()
+        self.assertFalse(self.device.isLaserOn())
+
+    def testSetPower(self):
+        self.device.setPower(0.5)
+        time.sleep(1.0)  # the debug port ramps power in a background thread
+        self.assertAlmostEqual(self.device.power(), 0.5, places=1)
+
+    def testShutdownReleasesPort(self):
+        self.device.shutdownDevice()
+        self.assertEqual(self.device.state, DeviceState.Recognized)
+        self.assertIsNone(self.device.port)
+
+
+class TestCoboltDevice(unittest.TestCase):
+    def setUp(self):
+        try:
+            self.device = CoboltDevice()
+            self.device.initializeDevice()
+        except Exception:
+            self.skipTest("No Cobolt laser connected")
+
+    def tearDown(self):
+        if self.device.state == DeviceState.Ready:
+            self.device.shutdownDevice()
+
+    def testReadPower(self):
+        self.assertIsNotNone(self.device.power())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hardwarelibrary/tests/testNotificationCenter.py
+++ b/hardwarelibrary/tests/testNotificationCenter.py
@@ -5,7 +5,7 @@ from enum import Enum
 from hardwarelibrary.notificationcenter import NotificationCenter, ObserverInfo
 
 
-class TestNotificationName(Enum):
+class NotificationNameTest(Enum):
     test       = "test"
     test2      = "test2"
     test3      = "test3"
@@ -26,37 +26,37 @@ class TestNotificationCenter(unittest.TestCase):
 
     def testSingletonCanPost(self):
         nc = NotificationCenter()
-        nc.postNotification(TestNotificationName.test, self)
+        nc.postNotification(NotificationNameTest.test, self)
 
     def testAddObserver(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
+        nc.addObserver(observer=self, method=self.handle, notificationName=NotificationNameTest.test)
 
     def testAddObserverCount(self):
         nc = NotificationCenter()
         self.assertEqual(nc.observersCount(), 0)
-        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
+        nc.addObserver(observer=self, method=self.handle, notificationName=NotificationNameTest.test)
         self.assertEqual(nc.observersCount(), 1)
 
     def testObserverInfo(self):
         nc = NotificationCenter()
-        observer = ObserverInfo(observer=self, method=self.handle, notificationName=TestNotificationName.test, observedObject=nc)
+        observer = ObserverInfo(observer=self, method=self.handle, notificationName=NotificationNameTest.test, observedObject=nc)
         
         self.assertTrue(observer.matches(ObserverInfo(observer=self)))
-        self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=TestNotificationName.test)))
+        self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=NotificationNameTest.test)))
         self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=None)))
-        self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=TestNotificationName.test, observedObject=nc)))
+        self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=NotificationNameTest.test, observedObject=nc)))
         self.assertTrue(observer.matches(ObserverInfo(observer=self, notificationName=None, observedObject=nc)))
 
         self.assertFalse(observer.matches(ObserverInfo(observer=nc)))
-        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName=TestNotificationName.test, observedObject=nc)))
-        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName=TestNotificationName.other, observedObject=nc)))
-        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName=TestNotificationName.other, observedObject=None)))
-        self.assertFalse(observer.matches(ObserverInfo(observer=self, notificationName=TestNotificationName.other, observedObject=None)))
+        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName=NotificationNameTest.test, observedObject=nc)))
+        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName=NotificationNameTest.other, observedObject=nc)))
+        self.assertFalse(observer.matches(ObserverInfo(observer=nc, notificationName=NotificationNameTest.other, observedObject=None)))
+        self.assertFalse(observer.matches(ObserverInfo(observer=self, notificationName=NotificationNameTest.other, observedObject=None)))
 
     def testAddObserverRemoveObserver(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
+        nc.addObserver(observer=self, method=self.handle, notificationName=NotificationNameTest.test)
         self.assertEqual(nc.observersCount(), 1)
         nc.removeObserver(observer=self)
         self.assertEqual(nc.observersCount(), 0)
@@ -69,24 +69,24 @@ class TestNotificationCenter(unittest.TestCase):
 
     def testAddObserverAnySenderAndPostithObject(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
-        nc.postNotification(notificationName=TestNotificationName.test, notifyingObject=self)
+        nc.addObserver(observer=self, method=self.handle, notificationName=NotificationNameTest.test)
+        nc.postNotification(notificationName=NotificationNameTest.test, notifyingObject=self)
         self.assertTrue(self.notificationReceived)
 
         nc.removeObserver(self)
 
     def testAddObserverAnySenderAndPostWithUserInfo(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.test)
-        nc.postNotification(notificationName=TestNotificationName.test, notifyingObject=self, userInfo="1234")
+        nc.addObserver(observer=self, method=self.handle, notificationName=NotificationNameTest.test)
+        nc.postNotification(notificationName=NotificationNameTest.test, notifyingObject=self, userInfo="1234")
         self.assertTrue(self.notificationReceived)
         self.assertEqual(self.postedUserInfo, "1234")
         nc.removeObserver(self)
 
     def testAddObserverWrongNotification(self):
         nc = NotificationCenter()
-        nc.addObserver(observer=self, method=self.handle, notificationName=TestNotificationName.wrong)
-        nc.postNotification(notificationName=TestNotificationName.test, notifyingObject=self, userInfo="1234")
+        nc.addObserver(observer=self, method=self.handle, notificationName=NotificationNameTest.wrong)
+        nc.postNotification(notificationName=NotificationNameTest.test, notifyingObject=self, userInfo="1234")
         self.assertFalse(self.notificationReceived)
         self.assertNotEqual(self.postedUserInfo, "1234")
         nc.removeObserver(self)
@@ -94,8 +94,8 @@ class TestNotificationCenter(unittest.TestCase):
     def testAddObserverWrongSender(self):
         someObject = NotificationCenter()
         nc = NotificationCenter()
-        nc.addObserver(self, method=self.handle, notificationName=TestNotificationName.test, observedObject=someObject)
-        nc.postNotification(notificationName=TestNotificationName.test, notifyingObject=self, userInfo="1234")
+        nc.addObserver(self, method=self.handle, notificationName=NotificationNameTest.test, observedObject=someObject)
+        nc.postNotification(notificationName=NotificationNameTest.test, notifyingObject=self, userInfo="1234")
         self.assertFalse(self.notificationReceived)
         self.assertNotEqual(self.postedUserInfo, "1234")
         nc.removeObserver(self)
@@ -103,46 +103,46 @@ class TestNotificationCenter(unittest.TestCase):
 
     def testAddObserverNoDuplicates(self):
         nc = NotificationCenter()
-        nc.addObserver(self, self.handle, TestNotificationName.test, None)
-        nc.addObserver(self, self.handle, TestNotificationName.test, None)
+        nc.addObserver(self, self.handle, NotificationNameTest.test, None)
+        nc.addObserver(self, self.handle, NotificationNameTest.test, None)
         self.assertEqual(nc.observersCount(), 1)
 
     def testAddObserverNoDuplicates2(self):
         nc = NotificationCenter()
-        nc.addObserver(self, self.handle, TestNotificationName.test, None)
-        nc.addObserver(self, self.handle, TestNotificationName.test2, None)
+        nc.addObserver(self, self.handle, NotificationNameTest.test, None)
+        nc.addObserver(self, self.handle, NotificationNameTest.test2, None)
         self.assertEqual(nc.observersCount(), 2)
 
     def testAddObserverNoDuplicates3(self):
         nc = NotificationCenter()
-        nc.addObserver(self, self.handle, TestNotificationName.test, None)
-        nc.addObserver(self, self.handle, TestNotificationName.test, nc)
+        nc.addObserver(self, self.handle, NotificationNameTest.test, None)
+        nc.addObserver(self, self.handle, NotificationNameTest.test, nc)
         self.assertEqual(nc.observersCount(), 1)
 
     def testRemoveIncorrectObject(self):
         nc = NotificationCenter()
         someObject = NotificationCenter()
-        nc.addObserver(self, self.handle, TestNotificationName.test, someObject)
+        nc.addObserver(self, self.handle, NotificationNameTest.test, someObject)
         nc.removeObserver(someObject)
         self.assertEqual(nc.observersCount(), 1)
 
     def testRemoveManyObservers(self):
         nc = NotificationCenter()
         someObject = NotificationCenter()
-        nc.addObserver(self, self.handle, TestNotificationName.test, someObject)
-        nc.addObserver(self, self.handle, TestNotificationName.test2, someObject)
-        nc.addObserver(self, self.handle, TestNotificationName.test3, someObject)
-        nc.addObserver(self, self.handle, TestNotificationName.test4, None)
+        nc.addObserver(self, self.handle, NotificationNameTest.test, someObject)
+        nc.addObserver(self, self.handle, NotificationNameTest.test2, someObject)
+        nc.addObserver(self, self.handle, NotificationNameTest.test3, someObject)
+        nc.addObserver(self, self.handle, NotificationNameTest.test4, None)
         nc.removeObserver(self)
         self.assertEqual(nc.observersCount(), 0)
 
     def testRemoveManyObservers2(self):
         nc = NotificationCenter()
         someObject = NotificationCenter()
-        nc.addObserver(self, self.handle, TestNotificationName.test, someObject)
-        nc.addObserver(self, self.handle, TestNotificationName.test2, someObject)
-        nc.addObserver(self, self.handle, TestNotificationName.test3, someObject)
-        nc.addObserver(self, self.handle, TestNotificationName.test4, None)
+        nc.addObserver(self, self.handle, NotificationNameTest.test, someObject)
+        nc.addObserver(self, self.handle, NotificationNameTest.test2, someObject)
+        nc.addObserver(self, self.handle, NotificationNameTest.test3, someObject)
+        nc.addObserver(self, self.handle, NotificationNameTest.test4, None)
         nc.removeObserver(self, observedObject=someObject)
         self.assertEqual(nc.observersCount(), 0)
 

--- a/hardwarelibrary/tests/testPhysicalDevice.py
+++ b/hardwarelibrary/tests/testPhysicalDevice.py
@@ -2,7 +2,7 @@ import env
 import unittest
 
 from hardwarelibrary.devicemanager import *
-from hardwarelibrary.motion import DebugLinearMotionDevice, SutterDevice, IntellidriveDevice
+from hardwarelibrary.motion import DebugLinearMotionDevice, DebugRotationDevice, SutterDevice, IntellidriveDevice
 from hardwarelibrary.notificationcenter import NotificationCenter
 from hardwarelibrary.physicaldevice import PhysicalDevice, DeviceState, PhysicalDeviceNotification
 from hardwarelibrary.powermeters import IntegraDevice
@@ -184,6 +184,30 @@ class TestLinearMotionPhysicalDevice(BaseTestCases.TestPhysicalDeviceBase):
     def setUp(self):
         super().setUp()
         self.device = DebugLinearMotionDevice()
+
+# Guards a past regression: DebugRotationDevice failed to construct (wrong
+# class reference) and shadowed orientation() with an attribute.
+class TestRotationPhysicalDevice(BaseTestCases.TestPhysicalDeviceBase):
+    def setUp(self):
+        super().setUp()
+        self.device = DebugRotationDevice()
+
+    def testOrientationIsCallable(self):
+        self.device.initializeDevice()
+        self.device.moveTo(45)
+        self.assertEqual(self.device.orientation(), 45)
+
+    def testMoveByAccumulates(self):
+        self.device.initializeDevice()
+        self.device.moveTo(45)
+        self.device.moveBy(10)
+        self.assertEqual(self.device.orientation(), 55)
+
+    def testHomeResetsOrientation(self):
+        self.device.initializeDevice()
+        self.device.moveTo(90)
+        self.device.home()
+        self.assertEqual(self.device.orientation(), 0)
 
 class TestSutterPhysicalDevice(BaseTestCases.TestPhysicalDeviceBase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Makes each device family's contract explicit and enforced. A new driver now
fails fast at instantiation with a clear message, instead of later at
runtime, and the methods to implement are visible at the top of each family
class.

## Changes (one commit per topic)

1. `PhysicalDevice` becomes an `abc.ABC`; `doInitializeDevice` /
   `doShutdownDevice` are abstract.
2. Each family base declares its `doXxx` hooks as `@abstractmethod`
   (`LinearMotionDevice`, `RotationDevice`, `LaserSourceDevice`,
   `PowerMeterDevice`, `CameraDevice`, `Spectrometer`). `LaserSourceDevice`
   becomes a `PhysicalDevice` subclass, with the matching `CoboltDevice` MRO
   and `__init__` argument-order fix.
3. The DAQ Protocols (`typing.Protocol` with `pass` bodies) are replaced by
   segregated ABC capability mixins: `AnalogInput/Output/IODevice` and
   `DigitalInput/Output/IODevice` (interface segregation). `LabjackDevice`
   combines the two IO mixins.
4. Fix `DebugRotationDevice`, which could not substitute for
   `RotationDevice` (NameError on construction, `orientation()` shadowed by
   an attribute), and add a regression test.
5. Rename the `TestNotificationName` enum (test data) to
   `NotificationNameTest` so pytest no longer tries to collect it, removing
   a `PytestCollectionWarning`.
6. Update `CLAUDE.md` and `README-4-New-device-coding-example.md` to
   document the ABC + `@abstractmethod` contract, the segregated DAQ
   capability mixins, and the choice to type-hint against the base classes.
7. Add `testCobolt.py`, a hardware-free test that drives `CoboltDevice`
   through its debug serial port. The laser family this PR reworks had no
   test; coverage goes from 0% to 100% (`lasersourcedevice.py`) and 93%
   (`cobolt.py`).

A consumer-facing `typing.Protocol` mirror per family was prototyped and
then dropped: the base classes already serve as the type for consumers,
which keeps a single source of truth and avoids Protocol/class drift.

## Test plan

The full suite passes with no hardware attached (hardware tests skip):
**274 passed (plus the new laser tests), 0 warnings**.

```
python3 -m pytest hardwarelibrary/tests/ \
  -o "python_files=test*.py" --continue-on-collection-errors
```

`testPhysicalDevice.py` now includes `TestRotationPhysicalDevice`, and
`testCobolt.py` is new. Coverage of the reworked code: motion 99-100%,
laser 93-100%, `physicaldevice.py`/DAQ 74-77%, `spectrometers/base.py` 55%.
`cameras/camera.py` stays uncovered (needs `cv2` and a camera).

Generated with [Claude Code](https://claude.com/claude-code)
