### PR TITLE
Fix LabjackDevice hardware path, make tests trustworthy, reach 100% coverage

### DIFF
--- a/hardwarelibrary/daq/labjackdevice.py
+++ b/hardwarelibrary/daq/labjackdevice.py
@@ -27,7 +27,7 @@ class LabjackDevice(PhysicalDevice, AnalogIODevice, DigitalIODevice):
 
     @property
     def isHighVoltage(self):
-        return hasattr(self.dev, 'hardwareVersion') and self.dev.hardwareVersion >= 2.0
+        return hasattr(self.dev, 'deviceName') and self.dev.deviceName == 'U3-HV'
 
     def setConfiguration(self, parameters: dict):
         raise NotImplementedError(

--- a/hardwarelibrary/daq/labjackdevice.py
+++ b/hardwarelibrary/daq/labjackdevice.py
@@ -15,7 +15,7 @@ class LabjackDevice(PhysicalDevice, AnalogIODevice, DigitalIODevice):
 
     def doInitializeDevice(self):
         self.dev = u3.U3(autoOpen=False)
-        if self.serialNumber == "*":
+        if self.serialNumber in ("*", ".*"):
             self.dev.open()
         else:
             self.dev.open(firstFound=False, serial=int(self.serialNumber))

--- a/hardwarelibrary/daq/labjackdevice.py
+++ b/hardwarelibrary/daq/labjackdevice.py
@@ -4,7 +4,12 @@ import u3
 
 
 class LabjackDevice(PhysicalDevice, AnalogIODevice, DigitalIODevice):
-    """LabJack U3 (LV and HV). Use self.dev for features beyond the wrapped methods."""
+    """LabJack U3 (LV and HV). Use self.dev for features beyond the wrapped methods.
+
+    The DAC outputs are slow: they are PWM-based (a ~732 Hz PWM signal smoothed by a
+    2nd-order ~16 Hz low-pass filter, ~10 ms time constant), so setAnalogVoltage
+    takes tens of ms to settle to its final value.
+    """
 
     classIdVendor = 0x0cd5
     classIdProduct = 0x003

--- a/hardwarelibrary/daq/labjackdevice.py
+++ b/hardwarelibrary/daq/labjackdevice.py
@@ -19,6 +19,11 @@ class LabjackDevice(PhysicalDevice, AnalogIODevice, DigitalIODevice):
         self.dev = None
 
     def doInitializeDevice(self):
+        """Open the first U3 found, or the one matching serialNumber.
+
+        PhysicalDevice normalizes a "*" or None serialNumber to the regex ".*",
+        so both spellings mean "first found"; any other value is an exact serial.
+        """
         self.dev = u3.U3(autoOpen=False)
         if self.serialNumber in ("*", ".*"):
             self.dev.open()
@@ -49,9 +54,12 @@ class LabjackDevice(PhysicalDevice, AnalogIODevice, DigitalIODevice):
         self.dev.configIO(**parameters)
 
     def getAnalogVoltage(self, channel):
+        """Returns volts."""
         return self.dev.getAIN(channel)
 
     def setAnalogVoltage(self, value, channel):
+        """value in volts, on DAC0 (channel 0) or DAC1 (channel 1)."""
+        # 5000/5002 are the U3 Modbus registers for DAC0/DAC1.
         if channel == 0:
             register = 5000
         elif channel == 1:

--- a/hardwarelibrary/tests/testLabjackU3.py
+++ b/hardwarelibrary/tests/testLabjackU3.py
@@ -163,6 +163,38 @@ class TestLabjackDevice(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.device.setConfiguration(None)
 
+    def testOpenBySerialNumber(self):
+        serialNumber = str(self.device.configuration()['SerialNumber'])
+        self.device.shutdownDevice()
+        try:
+            bySerial = LabjackDevice(serialNumber=serialNumber)
+            bySerial.initializeDevice()
+            self.assertEqual(str(bySerial.configuration()['SerialNumber']), serialNumber)
+            bySerial.shutdownDevice()
+        finally:
+            self.device.initializeDevice()
+
+    def testIsHighVoltage(self):
+        self.assertIsInstance(self.device.isHighVoltage, bool)
+
+    def testGetTemperature(self):
+        kelvin = self.device.getTemperature()
+        self.assertGreater(kelvin, 250)
+        self.assertLess(kelvin, 350)
+
+    def testToggleLED(self):
+        self.device.toggleLED()
+
+    def testSetAnalogVoltageInvalidChannel(self):
+        with self.assertRaises(ValueError):
+            self.device.setAnalogVoltage(value=1.0, channel=2)
+
+    def testConfigureAnalogIO(self):
+        self.device.configureAnalogIO({})
+
+    def testConfigureDigitalIO(self):
+        self.device.configureDigitalIO({})
+
 class TestDebugLabjackDevice(unittest.TestCase):
     def setUp(self):
         self.device = DebugLabjackDevice()

--- a/hardwarelibrary/tests/testLabjackU3.py
+++ b/hardwarelibrary/tests/testLabjackU3.py
@@ -1,5 +1,6 @@
 import env
 import unittest
+import u3
 
 from hardwarelibrary.devicemanager import *
 from hardwarelibrary.notificationcenter import NotificationCenter
@@ -11,12 +12,31 @@ from typing import Union, Optional, Protocol
 class TestLabjackDevice(unittest.TestCase):
     def setUp(self):
         super().setUp()
+        self.device = LabjackDevice()
+        self.assertIsNotNone(self.device)
         try:
-            self.device = LabjackDevice()
-            self.assertIsNotNone(self.device)
             self.device.initializeDevice()
-        except Exception as err:
-            self.skipTest("No Labjack connected")
+        except PhysicalDevice.UnableToInitialize as err:
+            cause = err.args[0] if err.args else None
+            if isinstance(cause, u3.LabJackException):
+                self.skipTest("No Labjack connected")
+            raise
+
+    def skipUnlessAnalogLoopback(self, channel):
+        self.device.setAnalogVoltage(value=0.5, channel=channel)
+        low = self.device.getAnalogVoltage(channel=channel)
+        self.device.setAnalogVoltage(value=2.5, channel=channel)
+        high = self.device.getAnalogVoltage(channel=channel)
+        if high - low < 1.0:
+            self.skipTest(f"DAC{channel} not jumpered to AIN{channel}")
+
+    def skipUnlessDigitalLoopback(self, outputChannel, inputChannel):
+        self.device.setDigitalValue(channel=outputChannel, value=True)
+        high = self.device.getDigitalValue(channel=inputChannel)
+        self.device.setDigitalValue(channel=outputChannel, value=False)
+        low = self.device.getDigitalValue(channel=inputChannel)
+        if not (high and not low):
+            self.skipTest(f"FIO{outputChannel} not jumpered to FIO{inputChannel}")
 
     def tearDown(self):
         super().tearDown()
@@ -46,7 +66,7 @@ class TestLabjackDevice(unittest.TestCase):
         self.assertAlmostEqual(value, 4.53, 1)
 
     def testSetAnalogValueChannel0(self):
-        # DAC0 conected to AIN0
+        self.skipUnlessAnalogLoopback(0)
         expectedValue = 1.5
         self.device.setAnalogVoltage(value=expectedValue, channel=0)
 
@@ -55,7 +75,7 @@ class TestLabjackDevice(unittest.TestCase):
         self.assertAlmostEqual(actualValue, expectedValue, 1)
 
     def testSetAnalogValueChannel1(self):
-        # DAC1 conected to AIN1
+        self.skipUnlessAnalogLoopback(1)
         expectedValue = 1.1
         self.device.setAnalogVoltage(value=expectedValue, channel=1)
 
@@ -82,17 +102,20 @@ class TestLabjackDevice(unittest.TestCase):
         self.assertEqual(actualValue, expectedValue)
 
     def testToggleDigitalValuesQuickly(self):
-        expectedValue = True
         outputChannel = 6
         inputChannel = 7
+        self.skipUnlessDigitalLoopback(outputChannel, inputChannel)
+
+        expectedValue = True
         loops = 1000
+        maxAttempts = 10
         while loops > 0:
             loops -= 1
             self.device.setDigitalValue(channel=outputChannel, value=expectedValue)
 
             actualValue = None
             attempts = 0
-            while actualValue != expectedValue:
+            while actualValue != expectedValue and attempts < maxAttempts:
                 actualValue = self.device.getDigitalValue(channel=inputChannel)
                 attempts = attempts + 1
             self.assertEqual(attempts, 1)

--- a/hardwarelibrary/tests/testLabjackU3.py
+++ b/hardwarelibrary/tests/testLabjackU3.py
@@ -1,5 +1,6 @@
 import env
 import unittest
+import time
 import u3
 
 from hardwarelibrary.devicemanager import *
@@ -10,6 +11,16 @@ from enum import Enum
 from typing import Union, Optional, Protocol
 
 class TestLabjackDevice(unittest.TestCase):
+    # The U3 DAC outputs are PWM-based, smoothed by a 2nd-order ~16 Hz low-pass
+    # filter (~10 ms time constant), so an AIN read immediately after setting a DAC
+    # returns the previous value. Wait for the output to settle before reading back.
+    analogSettlingTime = 0.15
+
+    def settledAnalogVoltage(self, value, channel):
+        self.device.setAnalogVoltage(value=value, channel=channel)
+        time.sleep(self.analogSettlingTime)
+        return self.device.getAnalogVoltage(channel=channel)
+
     def setUp(self):
         super().setUp()
         self.device = LabjackDevice()
@@ -23,10 +34,8 @@ class TestLabjackDevice(unittest.TestCase):
             raise
 
     def skipUnlessAnalogLoopback(self, channel):
-        self.device.setAnalogVoltage(value=0.5, channel=channel)
-        low = self.device.getAnalogVoltage(channel=channel)
-        self.device.setAnalogVoltage(value=2.5, channel=channel)
-        high = self.device.getAnalogVoltage(channel=channel)
+        low = self.settledAnalogVoltage(0.5, channel)
+        high = self.settledAnalogVoltage(2.5, channel)
         if high - low < 1.0:
             self.skipTest(f"DAC{channel} not jumpered to AIN{channel}")
 
@@ -68,20 +77,44 @@ class TestLabjackDevice(unittest.TestCase):
     def testSetAnalogValueChannel0(self):
         self.skipUnlessAnalogLoopback(0)
         expectedValue = 1.5
-        self.device.setAnalogVoltage(value=expectedValue, channel=0)
-
-        actualValue = self.device.getAnalogVoltage(channel=0)
+        actualValue = self.settledAnalogVoltage(expectedValue, 0)
         self.assertIsNotNone(actualValue)
         self.assertAlmostEqual(actualValue, expectedValue, 1)
 
     def testSetAnalogValueChannel1(self):
         self.skipUnlessAnalogLoopback(1)
         expectedValue = 1.1
-        self.device.setAnalogVoltage(value=expectedValue, channel=1)
-
-        actualValue = self.device.getAnalogVoltage(channel=1)
+        actualValue = self.settledAnalogVoltage(expectedValue, 1)
         self.assertIsNotNone(actualValue)
         self.assertAlmostEqual(actualValue, expectedValue, 1)
+
+    def testMeasureAnalogSettlingTime(self):
+        channel = 0
+        self.skipUnlessAnalogLoopback(channel)
+
+        target = 3.0
+        tolerance = 0.05
+        timeout = 1.0
+
+        self.device.setAnalogVoltage(value=0.0, channel=channel)
+        time.sleep(0.5)
+
+        start = time.perf_counter()
+        self.device.setAnalogVoltage(value=target, channel=channel)
+        settlingTime = None
+        reads = 0
+        while time.perf_counter() - start < timeout:
+            reads += 1
+            if abs(self.device.getAnalogVoltage(channel=channel) - target) <= tolerance:
+                settlingTime = time.perf_counter() - start
+                break
+
+        self.assertIsNotNone(settlingTime, f"AIN{channel} never reached {target} V within {timeout} s")
+        print(f"\nDAC{channel}->AIN{channel} full-scale step settled within {tolerance} V "
+              f"in {settlingTime * 1000:.1f} ms over {reads} reads (USB + DAC RC + ADC)")
+        self.assertLess(settlingTime, self.analogSettlingTime,
+                        f"measured settling {settlingTime * 1000:.1f} ms exceeds "
+                        f"analogSettlingTime {self.analogSettlingTime * 1000:.0f} ms used by the suite")
 
     def testSetDigitalValueChannel4(self):
         expectedValue = True


### PR DESCRIPTION
## Summary

Working on a real LabJack U3-HV surfaced two bugs that had silently broken the entire hardware path of `LabjackDevice` since the rewrite — both masked by tests that reported every failure as "No Labjack connected". This PR fixes them, makes the hardware tests trustworthy and hang-proof, characterizes and documents the U3 DAC settling behaviour, validates the docstrings, and brings line coverage of `labjackdevice.py` to 100%.

## Bug fixes

- **Open with default serial number** — `doInitializeDevice` compared `serialNumber == "*"`, but `PhysicalDevice.__init__` normalizes `"*"`/`None` to the regex `".*"`, so the default `LabjackDevice()` always hit `int(".*")` and raised `ValueError` on every initialize. Now treats `"*"` and `".*"` as the open-first-found wildcard.
- **`isHighVoltage` on U3-HV** — compared `hardwareVersion` (a string like `"1.30"`) `>= 2.0`, raising `TypeError`; the heuristic was also wrong (a U3-HV reports `hardwareVersion "1.30"`). Now detects via `deviceName == 'U3-HV'`.

## Test infrastructure

- `setUp` no longer swallows everything as "No Labjack connected" — it skips only on `u3.LabJackException` (genuine missing device); any other init error now fails the test (this catch-all is what hid both bugs above).
- The wiring-dependent loopback tests now probe for their jumper and skip with a clear reason when absent; `testToggleDigitalValuesQuickly`'s unbounded loop is bounded so it can no longer hang.
- Account for U3 DAC settling: the DAC outputs are PWM-based (~732 Hz) smoothed by a 2nd-order ~16 Hz low-pass filter (~10 ms time constant), so an AIN read immediately after a DAC write returns the previous value. Added `settledAnalogVoltage` (waits 0.15 s) and `testMeasureAnalogSettlingTime`, which times the end-to-end USB + DAC + ADC path (~37 ms measured).

## Docs & coverage

- Documented the non-obvious behaviour in `LabjackDevice` (PWM/slow DAC, the serialNumber wildcard normalization, the DAC Modbus registers, voltage units).
- Added hardware tests for the real-device methods that `DebugLabjackDevice` overrides, taking `labjackdevice.py` from 92% to **100%** line coverage. All new tests skip cleanly without hardware.

## Test results

On a connected U3-HV: 31 passed, 4 skipped (unwired DAC1→AIN1 / FIO6→FIO7 loopbacks and two pre-existing `@unittest.skip` read tests). With no hardware: the `TestLabjackDevice` class skips entirely and `TestDebugLabjackDevice` (16 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)