### PR TITLE
Skip LabJack hardware tests when the exodriver library is absent

### DIFF
--- a/hardwarelibrary/tests/testLabjackU3.py
+++ b/hardwarelibrary/tests/testLabjackU3.py
@@ -29,7 +29,11 @@ class TestLabjackDevice(unittest.TestCase):
             self.device.initializeDevice()
         except PhysicalDevice.UnableToInitialize as err:
             cause = err.args[0] if err.args else None
-            if isinstance(cause, u3.LabJackException):
+            # No device attached raises u3.LabJackException; a host without the
+            # native LabJack exodriver library raises AttributeError, because
+            # LabJackPython's staticLib is None. Either way there is no hardware
+            # to exercise, so skip rather than fail.
+            if isinstance(cause, (u3.LabJackException, AttributeError)):
                 self.skipTest("No Labjack connected")
             raise
 


### PR DESCRIPTION
## Problem
After the test CI from #94 started running on real runners, all 14 matrix jobs went red. The only failures were 21 tests in `testLabjackU3.py::TestLabjackDevice` (otherwise **351 passed, 210 skipped**).

`TestLabjackDevice.setUp` skipped only when `initializeDevice()` raised `u3.LabJackException` ("library installed, no device attached"). The CI runners have `LabJackPython` (a declared dependency) but **not** the native **exodriver** shared library, so the call instead raises:

```
AttributeError: 'NoneType' object has no attribute 'LJUSB_OpenDevice'
```

(LabJackPython's `staticLib` is `None`). That was not caught, so the tests failed instead of skipping — violating the project rule that hardware tests must `skipTest()` when no device is attached.

## Fix
Broaden the skip guard in `setUp` to treat `AttributeError` as another "no hardware" signature. Unexpected causes still re-raise; behaviour is unchanged where a real LabJack is connected.

## Verification
- Locally: `testLabjackU3.py` -> 21 passed, 23 skipped (no regression).
- Expected on CI: the 21 failures become skips, turning all matrix jobs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)