### PR TITLE
Update supported-devices table to match master

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ The library currently supports the following hardware:
 | | Ocean Insight USB2000+ | `USB2000Plus` | `0x2457:0x101E` | USB (PyUSB) |
 | | Ocean Insight USB4000 | `USB4000` | `0x2457:0x1022` | USB (PyUSB) |
 | | Ocean Insight USB650 | `USB650` | `0x2457:0x1014` | USB (PyUSB) |
+| | Ocean Insight SAS | `SAS` | `0x2457:0x1006` | USB (PyUSB) |
 | **Motion (linear)** | Sutter MP-285 | `SutterDevice` | `0x1342:0x0001` | Serial (FTDI) |
-| | Thorlabs KDC (K-Cube) | `ThorlabsDevice` | `0x0403:0xFAF0` | Serial (FTDI) |
-| | Thorlabs Kinesis | `ThorlabsKinesisDevice` | `0x0403:0xFAF0` | pylablib |
 | **Motion (rotation)** | Intellidrive | `IntellidriveDevice` | `0x0403:0x6001` | Serial (FTDI) |
 | **Laser sources** | Cobolt laser | `CoboltDevice` | (serial) | Serial |
+| | Spectra-Physics Millennia eV | `MillenniaEv25Device` | (serial) | Serial |
+| | Sirah Matisse | `MatisseDevice` | (TCP) | TCP/IP |
 | **Power meters** | Gentec-EO Integra | `IntegraDevice` | `0x1AD5:0x0300` | USB (PyUSB) |
 | **DAQ** | LabJack U3 | `LabjackDevice` | `0x0CD5:0x0003` | USB (LabJackPython) |
 | **Oscilloscopes** | Tektronix TDS series | `OscilloscopeDevice` | `0x0403:0x6001` | Serial (FTDI/SCPI) |


### PR DESCRIPTION
Brings the README "Supported devices" table in line with the drivers actually present on `master`.

## Added (implemented on master, were missing)
- **Ocean Insight SAS** spectrometer — `SAS` (`0x2457:0x1006`)
- **Spectra-Physics Millennia eV** laser — `MillenniaEv25Device` (serial)
- **Sirah Matisse** tunable laser — `MatisseDevice` (TCP/IP)

## Removed
- **Thorlabs KDC / Kinesis** rows — those drivers (`ThorlabsDevice`, `ThorlabsKinesisDevice`) live only on the unmerged `thorlabs-motors` branch, not on `master`. They will be re-added when that branch merges.

## Intentionally left as-is
Other Thorlabs references (the linear-motion code example and the architecture tree) are untouched, pending the `thorlabs-motors` merge that will make them valid against `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)