### PR TITLE
Millennia eV: status snapshot + preserve init error

### DIFF
--- a/hardwarelibrary/sources/millennia.py
+++ b/hardwarelibrary/sources/millennia.py
@@ -80,10 +80,13 @@ class MillenniaEv25Device(LaserSourceDevice, OnOffControl, ShutterControl, Power
             self.port = SerialPort(portPath=self.portPath)
             self.port.open(baudRate=self.defaultBaudRate)
             self.readIdentity()
-        except Exception:
+        except Exception as error:
             if self.port is not None and self.port.isOpen:
                 self.port.close()
-            raise PhysicalDevice.UnableToInitialize()
+            # Preserve the underlying error (e.g. pyserial's "[Errno 16]
+            # Resource busy") so callers can tell a busy port from a missing
+            # one instead of seeing a bare, info-less UnableToInitialize.
+            raise PhysicalDevice.UnableToInitialize(error) from error
 
     def readIdentity(self):
         # The eV identifies via the SCPI-style *IDN? query. The ?IDN form in
@@ -196,6 +199,20 @@ class MillenniaEv25Device(LaserSourceDevice, OnOffControl, ShutterControl, Power
         # ("4.90 W") depending on firmware; take the first whitespace-separated
         # token.
         return float(self.queryString("?P").split()[0])
+
+    # Status snapshot
+
+    def doGetStatusUserInfo(self) -> dict:
+        # Single-call snapshot for PhysicalDevice.startBackgroundStatusUpdates()
+        # (posted as PhysicalDeviceNotification.status) and for GUI polling: the
+        # output power plus the diode (emission) and shutter states. Without this
+        # override the base returns None, so the monitoring loop posts nothing
+        # useful for the eV.
+        return {
+            "power": self.doGetPower(),
+            "isLaserOn": self.doGetOnOffState(),
+            "isShutterOpen": self.doGetShutterState(),
+        }
 
 
 class DebugMillenniaEv25Device(MillenniaEv25Device):

--- a/hardwarelibrary/tests/testMillennia.py
+++ b/hardwarelibrary/tests/testMillennia.py
@@ -104,6 +104,15 @@ class TestDebugMillenniaEv25Device(unittest.TestCase):
         self.assertFalse(self.laser.isLaserOn())
         self.assertTrue(self.laser.isShutterOpen())  # off, shutter unchanged
 
+    def testStatusUserInfoSnapshotsPowerOnOffAndShutter(self):
+        self.laser.setPower(7.5)
+        self.laser.turnOn()
+        self.laser.openShutter()
+        self.assertEqual(
+            self.laser.doGetStatusUserInfo(),
+            {"power": 7.5, "isLaserOn": True, "isShutterOpen": True},
+        )
+
 
 class TestMillenniaEv25Device(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Two small gaps on the `MillenniaEv25Device` driver that currently push logic into downstream callers (found while building a GUI on top of it).

### 1. Preserve the underlying init error
`doInitializeDevice` caught any failure and raised a bare `PhysicalDevice.UnableToInitialize()`, discarding the original `serial.SerialException`. A caller could no longer distinguish a **busy** port (`[Errno 16] Resource busy`, e.g. the port held by another app) from a **missing** one — the GUI had to re-open the port itself just to classify the error. Now:

```python
raise PhysicalDevice.UnableToInitialize(error) from error
```

so the cause is preserved through the exception chain.

### 2. Implement `doGetStatusUserInfo()` for the eV
The framework already ships background monitoring (`startBackgroundStatusUpdates()` → `PhysicalDeviceNotification.status` via `NotificationCenter`), but `MillenniaEv25Device` didn't override `doGetStatusUserInfo()`, so the base returned `None` and the monitoring loop posted empty status for this device. Added an override returning a one-call snapshot:

```python
{"power": ..., "isLaserOn": ..., "isShutterOpen": ...}
```

usable both by the background loop and by GUI polling.

### Tests
Adds `testStatusUserInfoSnapshotsPowerOnOffAndShutter` to the debug-device suite; all `TestDebugMillenniaEv25Device` tests pass. No API breakage — both changes are additive/behaviour-preserving on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)