### PR TITLE
Add capability mixins to the power-meter family

### DIFF
--- a/hardwarelibrary/physicaldevice.py
+++ b/hardwarelibrary/physicaldevice.py
@@ -71,6 +71,13 @@ class PhysicalDevice(ABC):
         self.monitoring = None
         self.refreshInterval = 1.0
 
+        # Cooperative base: forward to the rest of the MRO so capability mixins
+        # mixed in alongside a device (e.g. WavelengthCalibratable) get their
+        # own __init__ run. The device-identity arguments are consumed here, so
+        # nothing is forwarded; a mixin __init__ must therefore take no required
+        # arguments and call super().__init__() itself.
+        super().__init__()
+
     @classmethod
     def vidpids(cls):
         if cls.usesGenericSerialConverter:

--- a/hardwarelibrary/powermeters/__init__.py
+++ b/hardwarelibrary/powermeters/__init__.py
@@ -1,4 +1,5 @@
 
+from .capabilities import Capability, WavelengthCalibratable, AutoScalable, ScaleAdjustable
 from .powermeterdevice import PowerMeterDevice
 from .integradevice import IntegraDevice
 from .fieldmasterdevice import FieldMasterDevice, DebugFieldMasterDevice

--- a/hardwarelibrary/powermeters/capabilities.py
+++ b/hardwarelibrary/powermeters/capabilities.py
@@ -1,0 +1,86 @@
+from abc import ABC, abstractmethod
+
+
+class Capability(ABC):
+    pass
+
+
+class WavelengthCalibratable(Capability):
+    unit = "nm"
+    isReadable = True
+    isWritable = True
+    calibrationWavelength = None
+
+    def getCalibrationWavelength(self):
+        self.doGetCalibrationWavelength()
+        return self.calibrationWavelength
+
+    def setCalibrationWavelength(self, wavelength):
+        self.doSetCalibrationWavelength(wavelength)
+        self.doGetCalibrationWavelength()
+
+    @abstractmethod
+    def doGetCalibrationWavelength(self):
+        ...
+
+    @abstractmethod
+    def doSetCalibrationWavelength(self, wavelength):
+        ...
+
+
+class AutoScalable(Capability):
+    # The meter picks its measurement range automatically when auto-scaling is
+    # on; turning it off pins the range to whatever scale is active. A meter may
+    # also expose ScaleAdjustable to choose that range by hand.
+    def autoScaleIsOn(self) -> bool:
+        return self.doGetAutoScale()
+
+    def turnAutoScaleOn(self):
+        self.doTurnAutoScaleOn()
+
+    def turnAutoScaleOff(self):
+        self.doTurnAutoScaleOff()
+
+    @abstractmethod
+    def doGetAutoScale(self) -> bool:
+        ...
+
+    @abstractmethod
+    def doTurnAutoScaleOn(self):
+        ...
+
+    @abstractmethod
+    def doTurnAutoScaleOff(self):
+        ...
+
+
+class ScaleAdjustable(Capability):
+    # The full-scale measurement range (e.g. 200e-3 W). Independent of
+    # AutoScalable: setting a scale by hand generally requires auto-scaling off.
+    unit = "W"
+    isReadable = True
+    isWritable = True
+    scale = None
+
+    def getScale(self):
+        self.doGetScale()
+        return self.scale
+
+    def setScale(self, scale):
+        self.doSetScale(scale)
+        self.doGetScale()
+
+    def availableScales(self) -> list:
+        return self.doGetAvailableScales()
+
+    @abstractmethod
+    def doGetScale(self):
+        ...
+
+    @abstractmethod
+    def doSetScale(self, scale):
+        ...
+
+    @abstractmethod
+    def doGetAvailableScales(self) -> list:
+        ...

--- a/hardwarelibrary/powermeters/capabilities.py
+++ b/hardwarelibrary/powermeters/capabilities.py
@@ -2,6 +2,11 @@ from abc import ABC, abstractmethod
 
 
 class Capability(ABC):
+    # Capability mixins are combined with a PhysicalDevice subclass, which sits
+    # ahead of them in the MRO. PhysicalDevice is a cooperative base (it calls
+    # super().__init__() after consuming the device-identity arguments), so a
+    # mixin that holds per-instance state may define __init__ as long as it
+    # takes no required arguments and forwards with super().__init__().
     pass
 
 
@@ -9,7 +14,10 @@ class WavelengthCalibratable(Capability):
     unit = "nm"
     isReadable = True
     isWritable = True
-    calibrationWavelength = None
+
+    def __init__(self):
+        super().__init__()
+        self.calibrationWavelength = None
 
     def getCalibrationWavelength(self):
         self.doGetCalibrationWavelength()
@@ -60,7 +68,10 @@ class ScaleAdjustable(Capability):
     unit = "W"
     isReadable = True
     isWritable = True
-    scale = None
+
+    def __init__(self):
+        super().__init__()
+        self.scale = None
 
     def getScale(self):
         self.doGetScale()

--- a/hardwarelibrary/powermeters/fieldmasterdevice.py
+++ b/hardwarelibrary/powermeters/fieldmasterdevice.py
@@ -157,10 +157,11 @@ class DebugFieldMasterDevice(FieldMasterDevice):
     usesGenericSerialConverter = False   # debug device has its own fake identity
 
     def __init__(self, serialNumber='debug'):
-        PhysicalDevice.__init__(self, serialNumber=serialNumber,
-                                idProduct=self.classIdProduct, idVendor=self.classIdVendor)
-        self.portPath = None
-        self.terminator = b'\n'
+        # Go through the full cooperative chain (FieldMaster -> PowerMeter ->
+        # PhysicalDevice -> mixins) with the debug identity, rather than jumping
+        # straight to PhysicalDevice and skipping the intermediate __init__s.
+        super().__init__(serialNumber=serialNumber,
+                         idProduct=self.classIdProduct, idVendor=self.classIdVendor)
         self.version = "Debug FieldMaster GS 1.0"
         self._simulatedPower = 1.43e-3
         self._calibrationWavelengthInNanometers = 1064.0

--- a/hardwarelibrary/powermeters/fieldmasterdevice.py
+++ b/hardwarelibrary/powermeters/fieldmasterdevice.py
@@ -7,11 +7,12 @@ from hardwarelibrary.communication.communicationport import (
 )
 from hardwarelibrary.physicaldevice import PhysicalDevice
 from hardwarelibrary.powermeters.powermeterdevice import PowerMeterDevice
+from hardwarelibrary.powermeters.capabilities import WavelengthCalibratable
 
 FLOAT_PATTERN = r"([-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)"
 
 
-class FieldMasterDevice(PowerMeterDevice):
+class FieldMasterDevice(PowerMeterDevice, WavelengthCalibratable):
     """Coherent FieldMaster GS laser power/energy meter over RS-232.
 
     The meter has no USB identity of its own: it connects through a generic

--- a/hardwarelibrary/powermeters/integradevice.py
+++ b/hardwarelibrary/powermeters/integradevice.py
@@ -2,9 +2,10 @@ import time
 from enum import Enum
 from hardwarelibrary.communication import USBPort, TextCommand, MultilineTextCommand
 from hardwarelibrary.powermeters.powermeterdevice import PowerMeterDevice
+from hardwarelibrary.powermeters.capabilities import WavelengthCalibratable
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification
 
-class IntegraDevice(PowerMeterDevice):
+class IntegraDevice(PowerMeterDevice, WavelengthCalibratable):
     classIdProduct = 0x0300
     classIdVendor = 0x1ad5
     commands = {

--- a/hardwarelibrary/powermeters/powermeterdevice.py
+++ b/hardwarelibrary/powermeters/powermeterdevice.py
@@ -5,6 +5,7 @@ from enum import Enum
 from hardwarelibrary.communication import USBPort, TextCommand
 from hardwarelibrary.physicaldevice import *
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification
+from hardwarelibrary.powermeters.capabilities import Capability
 
 class PowerMeterNotification(Enum):
     didMeasure     = "didMeasure"
@@ -14,20 +15,22 @@ class PowerMeterDevice(PhysicalDevice):
     def __init__(self, serialNumber:str, idProduct:int, idVendor:int):
         super().__init__(serialNumber, idProduct, idVendor)
         self.absolutePower = 0
-        self.calibrationWavelength = None
 
-    # Hardware hooks a driver must implement, on top of doInitializeDevice
-    # and doShutdownDevice inherited from PhysicalDevice.
+    def capabilities(self) -> list:
+        # The capability mixins, not the marker nor the device class itself
+        # (a driver is a Capability subclass too, but it is a PhysicalDevice).
+        return [klass for klass in type(self).__mro__
+                if issubclass(klass, Capability)
+                and klass is not Capability
+                and not issubclass(klass, PhysicalDevice)]
+
+    def hasCapability(self, capabilityClass) -> bool:
+        return isinstance(self, capabilityClass)
+
+    # Measuring absolute power is the one capability every power meter has, so
+    # its hook stays on the base; optional capabilities live in mixins.
     @abstractmethod
     def doGetAbsolutePower(self):
-        ...
-
-    @abstractmethod
-    def doGetCalibrationWavelength(self):
-        ...
-
-    @abstractmethod
-    def doSetCalibrationWavelength(self, wavelength):
         ...
 
     def measureAbsolutePower(self):
@@ -35,14 +38,6 @@ class PowerMeterDevice(PhysicalDevice):
         power = self.absolutePower
         NotificationCenter().postNotification(PowerMeterNotification.didMeasure, notifyingObject=self, userInfo=power)
         return power
-
-    def getCalibrationWavelength(self):
-        self.doGetCalibrationWavelength()
-        return self.calibrationWavelength
-
-    def setCalibrationWavelength(self, wavelength):
-        self.doSetCalibrationWavelength(wavelength)
-        self.doGetCalibrationWavelength()
 
     def doGetStatusUserInfo(self):
         return self.measureAbsolutePower()

--- a/hardwarelibrary/tests/testFieldMasterDevice.py
+++ b/hardwarelibrary/tests/testFieldMasterDevice.py
@@ -2,6 +2,9 @@ import env
 import unittest
 
 from hardwarelibrary.powermeters import FieldMasterDevice, DebugFieldMasterDevice
+from hardwarelibrary.powermeters import (
+    WavelengthCalibratable, AutoScalable, ScaleAdjustable,
+)
 from hardwarelibrary.powermeters.powermeterdevice import PowerMeterNotification
 from hardwarelibrary.notificationcenter import NotificationCenter
 
@@ -42,6 +45,28 @@ class TestDebugFieldMasterDevice(unittest.TestCase):
 
     def testEnergy(self):
         self.assertIsInstance(self.device.getEnergy(), float)
+
+
+class TestFieldMasterCapabilities(unittest.TestCase):
+    def setUp(self):
+        self.device = DebugFieldMasterDevice()
+
+    def testDeclaresWavelengthCalibratable(self):
+        self.assertTrue(self.device.hasCapability(WavelengthCalibratable))
+
+    def testDoesNotDeclareScaleCapabilities(self):
+        self.assertFalse(self.device.hasCapability(AutoScalable))
+        self.assertFalse(self.device.hasCapability(ScaleAdjustable))
+
+    def testCapabilitiesListsOnlyDeclaredMixins(self):
+        self.assertEqual(self.device.capabilities(), [WavelengthCalibratable])
+
+    def testCapabilitiesExcludeDeviceClass(self):
+        # The driver is itself a Capability subclass, but capabilities() must
+        # report only the mixins, never the device class or its base.
+        capabilities = self.device.capabilities()
+        self.assertNotIn(DebugFieldMasterDevice, capabilities)
+        self.assertNotIn(FieldMasterDevice, capabilities)
 
 
 class TestFieldMasterDevice(unittest.TestCase):


### PR DESCRIPTION
## Problem

`PowerMeterDevice` baked wavelength-calibration hooks directly into the base class even though not every meter calibrates by wavelength, and there was no way to introspect what a given meter can do. The laser-source family (`hardwarelibrary/sources/`) already models optional features as interface-segregated `Capability` mixins, but the power meters did not mirror that structure.

## Solution

Introduce `hardwarelibrary/powermeters/capabilities.py`, a mirror of `sources/capabilities.py`, with a `Capability` ABC and three orthogonal mixins:

| Mixin | Public API | `do*` hooks |
|---|---|---|
| `WavelengthCalibratable` | `getCalibrationWavelength` / `setCalibrationWavelength` | `doGetCalibrationWavelength`, `doSetCalibrationWavelength` |
| `AutoScalable` | `autoScaleIsOn` / `turnAutoScaleOn` / `turnAutoScaleOff` | `doGetAutoScale`, `doTurnAutoScaleOn`, `doTurnAutoScaleOff` |
| `ScaleAdjustable` | `getScale` / `setScale` / `availableScales` | `doGetScale`, `doSetScale`, `doGetAvailableScales` |

- `PowerMeterDevice` now keeps only the always-present `doGetAbsolutePower` hook and gains `capabilities()` / `hasCapability()` introspection, copied from `LaserSourceDevice`.
- Wavelength hooks moved out of the base into `WavelengthCalibratable`.
- `IntegraDevice` and `FieldMasterDevice` declare `WavelengthCalibratable`; their existing hooks satisfy the contract unchanged. `AutoScalable` / `ScaleAdjustable` are left for future auto-ranging meters — no driver falsely advertises them.
- `AutoScalable` and `ScaleAdjustable` are kept fully orthogonal; a driver that needs "auto off before manual scale" handles it in its own `doSetScale`.

## MRO / cooperative init (2nd commit)

Adding the mixins surfaced a latent init bug shared by the whole library. `PhysicalDevice.__init__` did **not** call `super().__init__()`, and in the MRO of a device that mixes in a capability it sits *ahead* of the mixins:

```
IntegraDevice -> PowerMeterDevice -> PhysicalDevice -> WavelengthCalibratable -> Capability -> ABC -> object
```

So the init chain terminated at `PhysicalDevice` and a mixin's `__init__` was **never reached** — mixins could only fake instance defaults with class attributes, and any future mixin holding real per-instance state would be silently skipped.

Fix:
- `PhysicalDevice.__init__` now ends with `super().__init__()`, making it a cooperative base. It still consumes the device-identity arguments and forwards nothing, so the contract (documented on `Capability`) is: a mixin `__init__` takes no required arguments and calls `super().__init__()` itself.
- `WavelengthCalibratable` / `ScaleAdjustable` now set their per-instance state (`calibrationWavelength`, `scale`) in a cooperative `__init__` instead of shared class attributes.
- `DebugFieldMasterDevice` routes through `super().__init__()` instead of calling `PhysicalDevice.__init__` directly, so it no longer skips `PowerMeterDevice` (`absolutePower` is now initialized to `0`).

Verified safe for every multiply-inheriting device (Matisse, Millennia, Labjack, Cobolt, power meters) — none of their mixins define an `__init__` to collide with.

## Tests

Adds `TestFieldMasterCapabilities` covering `capabilities()` / `hasCapability()`, including that the driver class does not leak into the reported list. Existing wavelength tests now exercise the mixin. Full suite: **398 passed, 235 skipped, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)