### PR TITLE
Prepare 1.3.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ API changes can land even when the minor version is unchanged.
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-06
+
 ### Added
 - Power-meter capability mixins (`powermeters/capabilities.py`), mirroring the
   laser-source `Capability` structure: `WavelengthCalibratable`


### PR DESCRIPTION
Moves the `[Unreleased]` changelog entries under a `## [1.3.1]` heading in preparation for cutting the release.

Contents of 1.3.1 (all already merged to `master`):
- Power-meter capability mixins `WavelengthCalibratable` / `AutoScalable` / `ScaleAdjustable` + `PowerMeterDevice.capabilities()` / `hasCapability()` (#105).
- `PhysicalDevice` made a cooperative init base so capability mixin `__init__`s run (#105).

Patch bump per preference; no existing device changes behavior, and the changelog's standing "API changes can land even when the minor version is unchanged" note covers the base-class adjustment.

After this merges, the release is cut by pushing the annotated tag `v1.3.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)