### PR TITLE
Import heavy third-party modules lazily (matplotlib, numpy, cv2)

### DIFF
--- a/hardwarelibrary/cameras/camera.py
+++ b/hardwarelibrary/cameras/camera.py
@@ -4,12 +4,6 @@ from enum import Enum
 from hardwarelibrary.physicaldevice import PhysicalDevice
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification
 from threading import Thread, RLock
-try:
-    import cv2
-except Exception as err:
-    print("No support for OpenCVcameras")
-    pass
-    
 import re
 
 class CameraDeviceNotification(Enum):
@@ -71,6 +65,8 @@ class CameraDevice(PhysicalDevice):
             raise RuntimeError("No monitoring loop running")
 
     def captureLoopSynchronous(self):
+        import cv2
+
         frame = None
         NotificationCenter().postNotification(notificationName=CameraDeviceNotification.didStartCapture,
                                               notifyingObject=self)
@@ -114,6 +110,8 @@ class OpenCVCamera(CameraDevice):
             self.cvCameraIndex = int(serialNumber)
 
     def openCVProperties(self):
+        import cv2
+
         properties = {}
         for property in dir(cv2):
             if re.search('CAP_', property) is not None:
@@ -139,6 +137,8 @@ class OpenCVCamera(CameraDevice):
         return wasAcquired
 
     def doInitializeDevice(self):
+        import cv2
+
         super().doInitializeDevice()
         with self.lock:
             # FIXME: Open the first camera we find

--- a/hardwarelibrary/echodevice.py
+++ b/hardwarelibrary/echodevice.py
@@ -8,8 +8,6 @@ import re
 import time
 from struct import *
 
-from pyftdi.ftdi import Ftdi #FIXME: should not be here.
-
 
 class EchoDevice(PhysicalDevice):
     classIdProduct = 0x6001

--- a/hardwarelibrary/motion/sutterdevice.py
+++ b/hardwarelibrary/motion/sutterdevice.py
@@ -10,8 +10,6 @@ import re
 import time
 from struct import *
 
-from pyftdi.ftdi import Ftdi #FIXME: should not be here.
-
 class SutterDevice(LinearMotionDevice):
     classIdVendor = 4930
     classIdProduct = 1

--- a/hardwarelibrary/oscilloscope/oscilloscopedevice.py
+++ b/hardwarelibrary/oscilloscope/oscilloscopedevice.py
@@ -4,7 +4,6 @@ import struct
 from hardwarelibrary.communication.serialport import SerialPort
 from hardwarelibrary.physicaldevice import *
 from hardwarelibrary.notificationcenter import NotificationCenter, Notification
-import matplotlib.pyplot as plt
 
 class Channels(Enum):
     CH1     = "CH1"
@@ -35,6 +34,8 @@ class OscilloscopeDevice(PhysicalDevice):
         self.delay = None
 
     def displayWaveforms(self, channels=None):
+        import matplotlib.pyplot as plt
+
         if channels is None:
             channels = [Channels.CH1, Channels.CH2]
 

--- a/hardwarelibrary/spectrometers/__init__.py
+++ b/hardwarelibrary/spectrometers/__init__.py
@@ -22,12 +22,12 @@ else:
 
 from .base import Spectrometer, getAllSubclasses
 from .oceaninsight import OISpectrometer, USB2000, USB4000, USB2000Plus, USB4000_2000Plus, USB650
-from .viewer import SpectraViewer
 
 def any() -> Spectrometer:
     return Spectrometer.any()
 
 def displayAny():
+    from .viewer import SpectraViewer
     spectrometer = Spectrometer.any()
     if spectrometer is not None:
         spectrometer.initializeDevice()

--- a/hardwarelibrary/spectrometers/base.py
+++ b/hardwarelibrary/spectrometers/base.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import time
-import numpy as np
 from abc import abstractmethod
 from struct import *
 import csv
@@ -17,7 +18,6 @@ import usb.backend.libusb1
 
 from pathlib import *
 from hardwarelibrary.physicaldevice import PhysicalDevice, DeviceState
-from hardwarelibrary.spectrometers.viewer import *
 
 class NoSpectrometerConnected(RuntimeError):
     pass
@@ -32,6 +32,8 @@ class Spectrometer(PhysicalDevice):
     idVendor = None
     idProduct = None
     def __init__(self, serialNumber=None, idProduct:int = None, idVendor:int = None):
+        import numpy as np
+
         PhysicalDevice.__init__(self, serialNumber=serialNumber, idProduct=idProduct, idVendor=idVendor)
         self.model = ""
         self.wavelength = np.linspace(400,1000,1024)
@@ -57,6 +59,7 @@ class Spectrometer(PhysicalDevice):
         """
         if self.state != DeviceState.Ready:
             self.initializeDevice()
+        from hardwarelibrary.spectrometers.viewer import SpectraViewer
         viewer = SpectraViewer(spectrometer=self)
         viewer.display()
 

--- a/hardwarelibrary/spectrometers/oceaninsight.py
+++ b/hardwarelibrary/spectrometers/oceaninsight.py
@@ -1,6 +1,5 @@
 try:
     import time
-    import numpy as np
     from struct import *
     import csv
     from typing import NamedTuple
@@ -17,18 +16,12 @@ try:
     import usb.util
     import usb.backend.libusb1
 
-    import matplotlib.backends as backends
-    import matplotlib.pyplot as plt
-    import matplotlib.animation as animation
-    from matplotlib.widgets import Button, TextBox
-
 
 except Exception as err:
     print('** Error importing modules. {0}'.format(err))
     print('We will attempt to continue and hope for the best.')
 
 from hardwarelibrary.spectrometers.base import *
-from hardwarelibrary.spectrometers.viewer import *
     
 """
 This is a simple script to use an Ocean Insight USB2000 spectrometer. You can
@@ -627,6 +620,8 @@ class USB2000(OISpectrometer):
             The spectrum, in 16-bit integers corresponding to each wavelength
             available in self.wavelength.
         """
+        import numpy as np
+
         spectrum = []
 
         for packet in range(32):
@@ -726,6 +721,8 @@ class USB4000_2000Plus(OISpectrometer):
             The spectrum, in 16-bit integers corresponding to each wavelength
             available in self.wavelength.
         """
+        import numpy as np
+
         spectrum = []
 
         if not self.lastStatus.isHighSpeed:
@@ -847,6 +844,8 @@ class DebugSpectro:
         intensity:float = None
 
     def __init__(self):
+        import numpy as np
+
         self.model = "Debug - Nothing is connected"
         self.wavelength = np.linspace(400,1000,1024)
         self.integrationTime = 10
@@ -862,6 +861,8 @@ class DebugSpectro:
         return "000-000-000"
 
     def getSpectrum(self):
+        import numpy as np
+
         spectrum = []
         time = self.getIntegrationTime()
         for wavelength in self.wavelength:
@@ -880,6 +881,7 @@ class DebugSpectro:
 
     def display(self):
         """ Display the spectrum with the SpectraViewer class."""
+        from hardwarelibrary.spectrometers.viewer import SpectraViewer
         viewer = SpectraViewer(spectrometer=self)
         viewer.display()
 


### PR DESCRIPTION
## Problem

`import hardwarelibrary` eagerly loaded `matplotlib` and `numpy` through the spectrometer and oscilloscope packages, even when nothing was ever plotted or acquired. Several imports were also dead: `oceaninsight.py` imported matplotlib it never used, and `SutterDevice`/`EchoDevice` imported `pyftdi.Ftdi` they never referenced (both already flagged `#FIXME: should not be here`).

## Solution

Defer each non-standard module to its point of use, and delete the dead imports:

- **Spectrometers** (`010ab73`): `SpectraViewer` now imported inside `display()`/`displayAny()`; `numpy` inside the `__init__`/`getSpectrum` methods that use it; `base.py` gains `from __future__ import annotations` so the `-> np.array` hint no longer forces numpy at class-definition time. Removed the unused matplotlib import block in `oceaninsight.py`. `viewer.py` is unchanged — it legitimately needs matplotlib and is now only imported when a viewer is shown.
- **Oscilloscope** (`ffb1457`): `matplotlib.pyplot` moved into `displayWaveforms()`, its only caller.
- **Cameras** (`ba2a102`): removed the top-level guarded `import cv2`; deferred into the three methods that use it. A missing OpenCV now surfaces as a clear `ModuleNotFoundError` only when a camera op is invoked, instead of a print at import time.
- **Dead imports** (`6013246`): removed unused `from pyftdi.ftdi import Ftdi` from `SutterDevice` and `EchoDevice`.

## Result

`import hardwarelibrary`: **336 ms -> 59 ms**, with `matplotlib` and `numpy` no longer loaded until you actually plot or acquire.

## Reviewed and left as-is

- `pyftdi` in `communication/serialport.py` — genuinely used across several methods, ~10 ms to import, core serial dependency.
- `pyserial`/`pyusb` — lightweight core comms deps, used pervasively.
- `u3` (LabJack) in `daq/labjackdevice.py` — not on the default import path.
- `pylablib` in `motion/thorlabs.py` — already lazily imported.

## Testing

Full suite: **398 passed, 235 skipped** (hardware-absent), unchanged from baseline.

Deferred paths exercised directly: `DebugSpectro.getSpectrum()` (numpy), oscilloscope + cameras imports without matplotlib/cv2 loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)