### PR TITLE
Prepare 1.3.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ API changes can land even when the minor version is unchanged.
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-07-08
+
+### Changed
+- Heavy third-party modules are now imported lazily, at their point of use,
+  instead of at module load. `import hardwarelibrary` no longer pulls in
+  `matplotlib` or `numpy` (import time drops from ~336 ms to ~59 ms); they load
+  only when a plot is drawn or a spectrum is acquired. Affected: the
+  spectrometers package (`SpectraViewer` deferred into `display()`/`displayAny()`,
+  `numpy` into the methods that use it; `base.py` uses
+  `from __future__ import annotations` for its `-> np.array` hint),
+  `OscilloscopeDevice.displayWaveforms`, and the cameras module (`cv2`). Public
+  APIs are unchanged. Two behavioral notes: importing `hardwarelibrary.cameras`
+  no longer prints a warning when OpenCV is absent — a missing `cv2` now raises
+  `ModuleNotFoundError` when a camera operation is invoked; and the unused
+  matplotlib import block in `oceaninsight.py` was removed.
+
+### Removed
+- Dead `from pyftdi.ftdi import Ftdi` imports in `SutterDevice` and `EchoDevice`
+  (both were unused and flagged `# FIXME: should not be here`). FTDI access still
+  goes through `SerialPort`, which owns the `pyftdi` dependency.
+
 ## [1.3.2] - 2026-07-07
 
 ### Added


### PR DESCRIPTION
Release notes for **1.3.3** (patch).

Records the lazy-import refactor merged in #110, plus removal of two dead `pyftdi` imports:

### Changed
- Heavy third-party modules (`matplotlib`, `numpy`, `cv2`) are now imported at their point of use rather than at module load. `import hardwarelibrary` drops from ~336 ms to ~59 ms and no longer pulls in matplotlib/numpy until a plot is drawn or a spectrum is acquired. Public APIs unchanged. Two behavioral notes: importing `hardwarelibrary.cameras` no longer warns when OpenCV is absent (a missing `cv2` raises `ModuleNotFoundError` when a camera op is invoked); the unused matplotlib import block in `oceaninsight.py` was removed.

### Removed
- Dead `from pyftdi.ftdi import Ftdi` imports in `SutterDevice` and `EchoDevice`.

Merging this, then tagging `v1.3.3`, cuts the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)